### PR TITLE
Take default values into account

### DIFF
--- a/src/common/Prop.js
+++ b/src/common/Prop.js
@@ -186,7 +186,10 @@ export default class Prop {
 			}
 		}
 		else if (change.source === "property" || change.source === "default") {
-			let value = change.value !== undefined ? change.value : change.element.props[this.name];
+			let value = change.value;
+			if (value === undefined) {
+				value = element === change.element ? change.element.props[this.name] : change.element[this.name];
+			}
 			console.log(change.element, this.name, change.element[this.name]);
 			element[this.name] = value;
 		}


### PR DESCRIPTION
For now, when we apply changes to a property on its change, we only consider authored properties. If I get the logic correctly, when `change.source` equals `default`, we should use the default value (from the prop spec) if it is provided.

@LeaVerou, could you please take a look at the proposed change? Do I get the logic correctly, or does this fix the `<channel-slider>` component by accident? 😅