### PR TITLE
First pass on fixing <color-picker>

### DIFF
--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -34,10 +34,9 @@ const self = class ColorPicker extends HTMLElement {
 		this._el.sliders.addEventListener("input", this);
 
 		if (!this.#initialized) {
-			// Create sliders
-			// this.propChangedCallback("space");
-
 			this.#initialized = true;
+
+			this._el.sliders.dispatchEvent(new Event("input"));
 		}
 	}
 
@@ -96,7 +95,10 @@ const self = class ColorPicker extends HTMLElement {
 			...ChannelSlider.props.get("defaultColor").spec
 		},
 		color: {
-			...ChannelSlider.props.get("color").spec
+			type: Color,
+			set (value) {
+				this.defaultColor = new Color(value).to(this.space);
+			},
 		},
 	}
 }


### PR DESCRIPTION
- When the component is mounted, we must dispatch the `input` event to update the corresponding color swatch.
- Previously, for the `color` prop, we used the corresponding spec from the `<channel-slider>`. But it depends on the `channel` property `<color-picker>` doesn't have. I'm sure the solution I suggest is not optimal at all. I just needed something to make the picker work.