### PR TITLE
Remove no longer necessary code

### DIFF
--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -4,7 +4,6 @@ import NudeElement from "../common/Element.js";
 import { getStep } from "../common/util.js";
 
 const Self = class ColorSlider extends NudeElement {
-	#initialized = false;
 	static postConstruct = [];
 	static tagName = "color-slider";
 
@@ -37,11 +36,6 @@ const Self = class ColorSlider extends NudeElement {
 
 		this._el.slider.addEventListener("input", this);
 		this._el.spinner.addEventListener("input", this);
-		if (!this.#initialized) {
-			this.#initialized = true;
-
-			this._el.slider.dispatchEvent(new Event("input"));
-		}
 	}
 
 	disconnectedCallback() {


### PR DESCRIPTION
We no longer need to fire the `input` event on initialization—everything is handled automatically by `valuechange`/`colorchange` event listeners.

This makes the `#initialized` property redundant and fixes the weirdness when the sider has two private `#initialized` properties (one inherited from the `NudeElement` class).