### PR TITLE
Fix typo in `defineEvent()`

### DIFF
--- a/src/common/defineEvents.js
+++ b/src/common/defineEvents.js
@@ -6,7 +6,7 @@ import {
 
 export function defineEvent (Class, name, options = {}) {
 	let onName = `on${name}`;
-	let isImplemented = name in Class.prototype;
+	let isImplemented = onName in Class.prototype;
 
 	if (!isImplemented) {
 		Props.add(Class, onName, {


### PR DESCRIPTION
Fixes the check whether `oneventname` is implemented in a class.