### PR TITLE
Fix spinner value precision

### DIFF
--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -58,7 +58,8 @@ const Self = class ColorSlider extends NudeElement {
 		if (["min", "max", "step", "value", "defaultValue"].includes(name)) {
 			prop.applyChange(this._el.slider, change);
 
-			let spinnerValue = this.tooltip === "progress" ? +(this.progress * 100).toPrecision(4) : this.value;
+			let spinnerValue = this.tooltip === "progress" ? this.progress * 100 : this.value;
+			spinnerValue = +spinnerValue.toPrecision(4);
 			prop.applyChange(this._el.spinner, {...change, value: spinnerValue});
 		}
 


### PR DESCRIPTION
We should avoid IEEE754 values not only when showing the progress but also the value.

Otherwise, we might end up with something like this:

<img width="1065" alt="image" src="https://github.com/color-js/elements/assets/9166277/270304cd-c9b0-44bb-9fe4-097db5aedd79">
