### PR TITLE
First attempt to fix issue #16

### DIFF
--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -63,7 +63,15 @@ const Self = class ColorSlider extends NudeElement {
 		if (["min", "max", "step", "value", "defaultValue"].includes(name)) {
 			prop.applyChange(this._el.slider, change);
 
-			let spinnerValue = this.tooltip === "progress" ? +(this.progress * 100).toPrecision(4) : this.value;
+			let spinnerValues = this;
+			if (this.tooltip === "progress") {
+				spinnerValues = {min: 0, max: 100, step: 1};
+
+				if (name === "value" || name === "defaultValue") {
+					spinnerValues[name] = +(this.progress * 100).toPrecision(4);
+				}
+			}
+			let spinnerValue = spinnerValues[name] ?? this[name];
 			prop.applyChange(this._el.spinner, {...change, value: spinnerValue});
 		}
 


### PR DESCRIPTION
For now, it doesn't fix anything—what was broken previously is still broken.
Why? At the element initialization, `this.tooltip` is `undefined`, so the spinner will get its values for `min`, `max`, and `step` from the corresponding properties of the slider.

Currently, after `<color-slider>` is initialized, `min`, `max`, and `step` remain unchanged, which means the corresponding values of the spinner aren't being updated. I'm trying to find a solution to this.

@LeaVerou Is there a proper way to call `propChangedCallback()`(or something else) for `min`, `max`, and `step` after the `<color-slider>` is initialized. I suspect it's possible to do from `connectedCallback()`, but I'm unsure how to do it properly.