### PR TITLE
[color-picker] Render the component on every change of `space`

### DIFF
--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -30,8 +30,6 @@ const Self = class ColorPicker extends NudeElement {
 		super.connectedCallback?.();
 		this._el.sliders.addEventListener("input", this);
 		this._el.swatch.addEventListener("input", this);
-
-		this.render();
 	}
 
 	disconnectedCallback() {
@@ -80,6 +78,8 @@ const Self = class ColorPicker extends NudeElement {
 					this._el.sliders.insertAdjacentHTML("beforeend", `<channel-slider space="${ this.space.id }" channel="${ channel }"></channel-slider>`);
 				}
 			}
+
+			this.render();
 		}
 
 		if (name === "color") {


### PR DESCRIPTION
This also includes the default `space`. That's why we no longer need to render `<color-picker>` after the component is connected.

This also solves the issue with setting `space` programmatically—with this PR merged, it'll work as expected.