### PR TITLE
[color-slider] Fix active style in WebKit-based browsers

### DIFF
--- a/src/color-slider/color-slider.css
+++ b/src/color-slider/color-slider.css
@@ -66,11 +66,6 @@
 		transition: 200ms, 0s background;
 	}
 
-		&::-webkit-slider-thumb:active {
-			border: var(--_slider-thumb-border-active);
-			scale: var(--_slider-thumb-scale-active);
-		}
-
 		&::-moz-range-thumb:active {
 			border: var(--_slider-thumb-border-active);
 			scale: var(--_slider-thumb-scale-active);
@@ -79,6 +74,12 @@
 	&::-moz-range-track {
 		background: none;
 	}
+}
+
+/* For some reason, the &::-webkit-slider-thumb:active rule (previously used inside the above rule) doesn't work 🤷‍♂️ */
+.color-slider::-webkit-slider-thumb:active {
+	border: var(--_slider-thumb-border-active);
+	scale: var(--_slider-thumb-scale-active);
 }
 
 .slider-tooltip {

--- a/src/color-slider/color-slider.css
+++ b/src/color-slider/color-slider.css
@@ -77,6 +77,7 @@
 }
 
 /* For some reason, the &::-webkit-slider-thumb:active rule (previously used inside the above rule) doesn't work 🤷‍♂️ */
+/* DO NOT MOVE IT BACK! :) */
 .color-slider::-webkit-slider-thumb:active {
 	border: var(--_slider-thumb-border-active);
 	scale: var(--_slider-thumb-scale-active);


### PR DESCRIPTION
For some reason, the `&::-webkit-slider-thumb:active` rule doesn't work.