### PR TITLE
[color-picker] Fix regression when provided color was replaced by the default one on component initialization

### DIFF
--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -30,6 +30,8 @@ const Self = class ColorPicker extends NudeElement {
 		super.connectedCallback?.();
 		this._el.sliders.addEventListener("input", this);
 		this._el.swatch.addEventListener("input", this);
+
+		this.render();
 	}
 
 	disconnectedCallback() {
@@ -79,7 +81,12 @@ const Self = class ColorPicker extends NudeElement {
 				}
 			}
 
-			this.render();
+			// When we first come here on component initialization,
+			// we shouldn't call render() since it'll replace the provided color with the default one.
+			// So, we only need to re-render the component when space actually changes *after* the component is mounted.
+			if (change.oldInternalValue || change.oldAttributeValue) {
+				this.render();
+			}
 		}
 
 		if (name === "color") {


### PR DESCRIPTION
When we render `<color-picker>` in the process of its initialization (on `space` change), we replace the color (provided via the `color` attribute) with the default one. We definitely don't want it. I noticed this earlier, but yesterday, it slipped my mind. Sorry about that. This PR should fix the regression.