### PR TITLE
[channel-slider] Add info about slots and parts to the docs

### DIFF
--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -109,6 +109,12 @@ All attributes are reactive:
 
 ## Reference
 
+### Slots
+
+| Name | Description |
+|------|-------------|
+| (default) | The channel slider's label. |
+
 ### Attributes & Properties
 
 | Attribute | Property | Property type | Default value | Description |
@@ -131,3 +137,11 @@ All attributes are reactive:
 | `change` | Fired when the color changes due to user action. |
 | `valuechange` | Fired when the value changes for any reason, and once during initialization. |
 | `colorchange` | Fired when the color changes for any reason, and once during initialization. |
+
+### Parts
+
+| Name | Description |
+|------|-------------|
+| `color_slider` | The internal `<color-slider>` element. |
+| `slider` | The exposed [part of the internal `<color-slider>` element](../color-slider/#parts). |
+| `label` | The internal `<label>` element used as a wrapper around the default slot and the slider. |

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -143,5 +143,5 @@ All attributes are reactive:
 | Name | Description |
 |------|-------------|
 | `color_slider` | The internal `<color-slider>` element. |
-| `slider` | The exposed [part of the internal `<color-slider>` element](../color-slider/#parts). |
+| `slider` | The `slider` part of the internal [`<color-slider>`](../color-slider/#parts) element. |
 | `label` | The internal `<label>` element used as a wrapper around the default slot and the slider. |

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -113,7 +113,7 @@ All attributes are reactive:
 
 | Name | Description |
 |------|-------------|
-| (default) | The channel slider's label. |
+| _(default)_ | The channel slider's label. |
 
 ### Attributes & Properties
 


### PR DESCRIPTION
I'm unsure whether I correctly described the exposed part of `<color-slider>`. Should we document `exportparts`?