### PR TITLE
[color-slider] Fix the spinner `min`, `max`, and `step` values

### DIFF
--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -63,7 +63,10 @@ const Self = class ColorSlider extends NudeElement {
 		if (["min", "max", "step", "value", "defaultValue"].includes(name)) {
 			prop.applyChange(this._el.slider, change);
 
-			let spinnerValue = this.tooltip === "progress" ? +(this.progress * 100).toPrecision(4) : change.value;
+			let spinnerValue = change.value;
+			if (this.tooltip === "progress" && (name === "value" || name === "defaultValue")) {
+				spinnerValue = +(this.progress * 100).toPrecision(4);
+			}
 			prop.applyChange(this._el.spinner, {...change, value: spinnerValue});
 		}
 

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -63,11 +63,11 @@ const Self = class ColorSlider extends NudeElement {
 		if (["min", "max", "step", "value", "defaultValue"].includes(name)) {
 			prop.applyChange(this._el.slider, change);
 
-			let spinnerValue = change.value;
+			let value = change.value;
 			if (this.tooltip === "progress" && (name === "value" || name === "defaultValue")) {
-				spinnerValue = +(this.progress * 100).toPrecision(4);
+				value = +(this.progress * 100).toPrecision(4);
 			}
-			prop.applyChange(this._el.spinner, {...change, value: spinnerValue});
+			prop.applyChange(this._el.spinner, {...change, value});
 		}
 
 		if (name === "stops") {

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -63,7 +63,7 @@ const Self = class ColorSlider extends NudeElement {
 		if (["min", "max", "step", "value", "defaultValue"].includes(name)) {
 			prop.applyChange(this._el.slider, change);
 
-			let spinnerValue = this.tooltip === "progress" ? +(this.progress * 100).toPrecision(4) : this.value;
+			let spinnerValue = this.tooltip === "progress" ? +(this.progress * 100).toPrecision(4) : change.value;
 			prop.applyChange(this._el.spinner, {...change, value: spinnerValue});
 		}
 


### PR DESCRIPTION
Previously, if specified on `<color-slider>`, they all became equal to the slider value, not the corresponding prop's value.
This PR fixes it.