### PR TITLE
[color-swatch] Make content reactive

### DIFF
--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -54,6 +54,10 @@ const Self = class ColorSwatch extends NudeElement {
 				this.value = evt.target.value;
 			});
 		}
+
+		if (this.static) {
+			this.value = this.textContent.trim();
+		}
 	}
 
 	get gamut () {


### PR DESCRIPTION
This PR fixes an issue with this demo when the swatch didn't update either on interaction with the slider or button clicks:

```html
<button onclick="this.nextElementSibling.value = Math.random()">Random color</button>
<color-slider space="oklch"
              stops="gold, darkcyan, indigo"
              oncolorchange="this.nextElementSibling.textContent = this.color"></color-slider>
<color-swatch></color-swatch>
```