### PR TITLE
[color-swatch] Update the corresponding custom CSS properties on the `gamuts` change, fixes #79

### DIFF
--- a/src/gamut-badge/gamut-badge.js
+++ b/src/gamut-badge/gamut-badge.js
@@ -31,7 +31,7 @@ const Self = class GamutBadge extends NudeElement {
 			this.style.setProperty("--gamut-count", this.gamuts.length - 1);
 		}
 
-		if (name === "gamut") {
+		if (name === "gamut" || name === "gamuts") {
 			if (this.gamutInfo) {
 				this.style.setProperty("--gamut-level", this.gamutInfo.level);
 				this.style.setProperty("--gamut-label", `"${ this.gamutInfo.label }"`);
@@ -46,6 +46,9 @@ const Self = class GamutBadge extends NudeElement {
 	}
 
 	static props = {
+		color: {
+			type: Color,
+		},
 		gamuts: {
 			type: Array,
 			default: "srgb, p3, rec2020, prophoto",
@@ -104,9 +107,6 @@ const Self = class GamutBadge extends NudeElement {
 			get () {
 				return this.gamutInfo?.id;
 			},
-		},
-		color: {
-			type: Color,
 		},
 	};
 

--- a/src/gamut-badge/gamut-badge.js
+++ b/src/gamut-badge/gamut-badge.js
@@ -31,7 +31,7 @@ const Self = class GamutBadge extends NudeElement {
 			this.style.setProperty("--gamut-count", this.gamuts.length - 1);
 		}
 
-		if (name === "gamut" || name === "gamuts") {
+		if (name === "gamutInfo") {
 			if (this.gamutInfo) {
 				this.style.setProperty("--gamut-level", this.gamutInfo.level);
 				this.style.setProperty("--gamut-label", `"${ this.gamutInfo.label }"`);

--- a/src/gamut-badge/gamut-badge.js
+++ b/src/gamut-badge/gamut-badge.js
@@ -46,9 +46,6 @@ const Self = class GamutBadge extends NudeElement {
 	}
 
 	static props = {
-		color: {
-			type: Color,
-		},
 		gamuts: {
 			type: Array,
 			default: "srgb, p3, rec2020, prophoto",
@@ -107,6 +104,9 @@ const Self = class GamutBadge extends NudeElement {
 			get () {
 				return this.gamutInfo?.id;
 			},
+		},
+		color: {
+			type: Color,
 		},
 	};
 


### PR DESCRIPTION
In the dependency graph, the order of props also matters—`gamuts` should be updated before `color`.