### PR TITLE
[color-swatch][color-scale] First stab at implementing the coords prop

### DIFF
--- a/src/color-scale/color-scale.js
+++ b/src/color-scale/color-scale.js
@@ -66,8 +66,10 @@ const Self = class ColorScale extends NudeElement {
 			}
 
 			swatch.color = color;
-			swatch.coords = this.coords;
 			swatch.textContent = name;
+			if (this.coords) {
+				swatch.coords = this.coords;
+			}
 			i++;
 		}
 

--- a/src/color-scale/color-scale.js
+++ b/src/color-scale/color-scale.js
@@ -148,7 +148,7 @@ const Self = class ColorScale extends NudeElement {
 
 				return colors;
 			},
-			dependencies: ["colors", "steps", "space", "coords"],
+			additionalDependencies: ["coords"],
 		},
 		coords: {},
 	};

--- a/src/color-scale/color-scale.js
+++ b/src/color-scale/color-scale.js
@@ -66,6 +66,7 @@ const Self = class ColorScale extends NudeElement {
 			}
 
 			swatch.color = color;
+			swatch.coords = this.coords;
 			swatch.textContent = name;
 			i++;
 		}
@@ -144,7 +145,11 @@ const Self = class ColorScale extends NudeElement {
 				}
 
 				return colors;
-			}
+			},
+			dependencies: ["colors", "steps", "space", "coords"],
+		},
+		coords: {
+			type: String,
 		},
 	};
 }

--- a/src/color-scale/color-scale.js
+++ b/src/color-scale/color-scale.js
@@ -150,9 +150,7 @@ const Self = class ColorScale extends NudeElement {
 			},
 			dependencies: ["colors", "steps", "space", "coords"],
 		},
-		coords: {
-			type: String,
-		},
+		coords: {},
 	};
 }
 

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -74,6 +74,10 @@ slot {
 			font-variant-numeric: tabular-nums;
 		}
 	}
+
+	&:empty {
+		display: none;
+	}
 }
 
 #wrapper {

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -49,6 +49,23 @@ slot {
 	}
 }
 
+#coords {
+	margin: 0;
+	display: grid;
+	grid-template-columns: max-content auto;
+	gap: .3em .7em;
+
+	.coord {
+		display: contents;
+
+		dd {
+			margin: 0;
+			font-weight: bold;
+			font-variant-numeric: tabular-nums;
+		}
+	}
+}
+
 #wrapper {
 	display: flex;
 	flex-flow: inherit;

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -51,12 +51,22 @@ slot {
 
 #coords {
 	margin: 0;
-	display: grid;
-	grid-template-columns: max-content auto;
-	gap: .3em .7em;
+	display: inline-flex;
+	gap: .5em;
+
+	&:is(:host([size="large"]) &) {
+		display: grid;
+		grid-template-columns: max-content auto;
+		gap: .3em .7em;
+
+		.coord {
+			display: contents;
+		}
+	}
 
 	.coord {
-		display: contents;
+		display: flex;
+		gap: .2em;
 
 		dd {
 			margin: 0;

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -49,7 +49,7 @@ slot {
 	}
 }
 
-#coords {
+[part="coords"] {
 	margin: 0;
 	display: inline-flex;
 	gap: .5em;
@@ -73,10 +73,6 @@ slot {
 			font-weight: bold;
 			font-variant-numeric: tabular-nums;
 		}
-	}
-
-	&:empty {
-		display: none;
 	}
 }
 

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -178,7 +178,6 @@ const Self = class ColorSwatch extends NudeElement {
 			reflect: {
 				from: true,
 			},
-			dependencies: ["color"],
 		},
 	}
 

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -125,10 +125,10 @@ const Self = class ColorSwatch extends NudeElement {
 				let {space, id: channel} = Color.Space.resolveCoord(properties);
 
 				let value = this.color[space.id];
-
 				if (channel) {
 					value = value[channel];
 				}
+				value = +value.toPrecision(4);
 
 				coords.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
 			}

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -170,15 +170,7 @@ const Self = class ColorSwatch extends NudeElement {
 				is: Array,
 				values: {
 					is: Object,
-					defaultKey: (value, i) => {
-						let [space, channel] = value.split(".");
-						if (!channel) {
-							channel = space;
-							space = this.color?.space.id;
-						}
-
-						return Color.Space.get(space)?.coords[channel]?.name ?? channel;
-					},
+					defaultKey: (coord, i) => Color.Space.resolveCoord(coord)?.name,
 				},
 			},
 			default: [],

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -118,7 +118,6 @@ const Self = class ColorSwatch extends NudeElement {
 				for (let coord of this.coords) {
 					let [label, properties] = Object.entries(coord)[0];
 					let [space, channel] = properties.split(".");
-					let value;
 
 					let value = this.color[space];
 

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -118,9 +118,9 @@ const Self = class ColorSwatch extends NudeElement {
 				let coords = [];
 				for (let coord of this.coords) {
 					let [label, properties] = Object.entries(coord)[0];
-					let [space, channel] = properties.split(".");
+					let {space, id: channel} = Color.Space.resolveCoord(properties);
 
-					let value = this.color[space];
+					let value = this.color[space.id];
 
 					if (channel) {
 						value = value[channel];

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -110,28 +110,30 @@ const Self = class ColorSwatch extends NudeElement {
 		}
 
 		if (name === "coords") {
-			if (this.color) {
-				if (!this._el.coords) {
-					this._el.colorWrapper.insertAdjacentHTML("afterend", `<dl part="coords"></dl>`);
-					this._el.coords = this._el.colorWrapper.nextElementSibling;
-				}
-
-				let coords = [];
-				for (let coord of this.coords) {
-					let [label, properties] = Object.entries(coord)[0];
-					let {space, id: channel} = Color.Space.resolveCoord(properties);
-
-					let value = this.color[space.id];
-
-					if (channel) {
-						value = value[channel];
-					}
-
-					coords.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
-				}
-
-				this._el.coords.innerHTML = coords.join("\n");
+			if (!this.coords.length) {
+				return;
 			}
+
+			if (!this._el.coords) {
+				this._el.colorWrapper.insertAdjacentHTML("afterend", `<dl part="coords"></dl>`);
+				this._el.coords = this._el.colorWrapper.nextElementSibling;
+			}
+
+			let coords = [];
+			for (let coord of this.coords) {
+				let [label, properties] = Object.entries(coord)[0];
+				let {space, id: channel} = Color.Space.resolveCoord(properties);
+
+				let value = this.color[space.id];
+
+				if (channel) {
+					value = value[channel];
+				}
+
+				coords.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
+			}
+
+			this._el.coords.innerHTML = coords.join("\n");
 		}
 	}
 
@@ -179,6 +181,7 @@ const Self = class ColorSwatch extends NudeElement {
 			reflect: {
 				from: true,
 			},
+			dependencies: ["color"],
 		},
 	}
 

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -114,9 +114,9 @@ const Self = class ColorSwatch extends NudeElement {
 				return;
 			}
 
-			if (!this._el.coords) {
-				this._el.colorWrapper.insertAdjacentHTML("afterend", `<dl part="coords"></dl>`);
-				this._el.coords = this._el.colorWrapper.nextElementSibling;
+			this._el.coords ??= Object.assign(document.createElement("dl"), {part: "coords"});
+			if (!this._el.coords.parentNode) {
+				this._el.colorWrapper.after(this._el.coords);
 			}
 
 			let coords = [];

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -113,7 +113,7 @@ const Self = class ColorSwatch extends NudeElement {
 
 		if (name === "coords") {
 			if (this.color) {
-				this._el.coords?.replaceChildren(); // remove all children
+				this._el.coords.textContent = ""; // remove all children
 
 				for (let coord of this.coords) {
 					let [label, properties] = Object.entries(coord)[0];

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -115,6 +115,7 @@ const Self = class ColorSwatch extends NudeElement {
 			if (this.color) {
 				this._el.coords.textContent = ""; // remove all children
 
+				let coords = [];
 				for (let coord of this.coords) {
 					let [label, properties] = Object.entries(coord)[0];
 					let [space, channel] = properties.split(".");
@@ -125,8 +126,10 @@ const Self = class ColorSwatch extends NudeElement {
 						value = value[channel];
 					}
 
-					this._el.coords.insertAdjacentHTML("beforeend", `<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
+					coords.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
 				}
+
+				this._el.coords.innerHTML = coords.join("\n");
 			}
 		}
 	}

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -24,7 +24,6 @@ const Self = class ColorSwatch extends NudeElement {
 				<div part="color-wrapper">
 					<slot></slot>
 				</div>
-				<dl id="coords" part="coords"></dl>
 				<slot name="after"></slot>
 			</div>
 		`;
@@ -113,7 +112,10 @@ const Self = class ColorSwatch extends NudeElement {
 
 		if (name === "coords") {
 			if (this.color) {
-				this._el.coords.textContent = ""; // remove all children
+				if (!this._el.coords) {
+					this._el.colorWrapper.insertAdjacentHTML("afterend", `<dl part="coords"></dl>`);
+					this._el.coords = this._el.colorWrapper.nextElementSibling;
+				}
 
 				let coords = [];
 				for (let coord of this.coords) {

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -31,7 +31,6 @@ const Self = class ColorSwatch extends NudeElement {
 		this._el = {};
 		this._el.wrapper = this.shadowRoot.querySelector("#wrapper");
 		this._el.colorWrapper = this.shadowRoot.querySelector("[part=color-wrapper]");
-		this._el.coords = this.shadowRoot.querySelector("#coords");
 		this._el.slot = this.shadowRoot.querySelector("slot:not([name])");
 
 		this.#updateStatic();

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -121,13 +121,9 @@ const Self = class ColorSwatch extends NudeElement {
 
 			let coords = [];
 			for (let coord of this.coords) {
-				let [label, properties] = Object.entries(coord)[0];
-				let {space, id: channel} = Color.Space.resolveCoord(properties);
+				let [label, channel] = Object.entries(coord)[0];
 
-				let value = this.color[space.id];
-				if (channel) {
-					value = value[channel];
-				}
+				let value = this.color.get(channel);
 				value = +value.toPrecision(4);
 
 				coords.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -115,7 +115,7 @@ const Self = class ColorSwatch extends NudeElement {
 			if (this.color) {
 				this._el.coords?.replaceChildren(); // remove all children
 
-				for (let coord of this.coords ?? []) {
+				for (let coord of this.coords) {
 					let [label, properties] = Object.entries(coord)[0];
 					let [space, channel] = properties.split(".");
 					let value;
@@ -181,6 +181,7 @@ const Self = class ColorSwatch extends NudeElement {
 					},
 				},
 			},
+			default: [],
 			reflect: {
 				from: true,
 			},


### PR DESCRIPTION
It's a very basic implementation, so we could have something to start with. 🙂
It looks like this:

<img width="1301" alt="SCR-20240607-bwjc" src="https://github.com/color-js/elements/assets/9166277/10ab30c4-73bf-4e00-8934-64ae913444dd">

When defining the type of `coords`, I used a workaround because of [the issue](https://github.com/nudeui/element/issues/27) I faced.

I wonder whether we should do something like `+(value).toPrecision(4)` to make the output look nicer (or is it OK to see that many digits?). Is there a way to specify precision in `Color.js` we could use?

**UPDATE**

Here is the code that produces the image above:


```html
<color-swatch coords="oklch.l, oklch.c, oklch.h" size="large">oklch(80% 50% 70)</color-swatch>

<div id="future_swatch_container"></div>
<script>
	let swatch = document.createElement("color-swatch");
	swatch.color = "oklch(65% 0.15 210)";
	swatch.setAttribute("size", "large");
	swatch.textContent = "Turquoise";
	swatch.coords = "L: oklch.l, C: oklch.c, H: oklch.h";
	future_swatch_container.append(swatch);
</script>

<color-scale colors="#e3fafc, #0b7285" steps="4" space="oklch" coords="L: oklch.l, C: oklch.c"></color-scale>

<color-scale space="oklch" colors="
	Gray 50: #f9fafb,
	Gray 100: #f3f4f6,
	Gray 200: #e5e7eb,
	Gray 300: #d1d5db,
	Gray 400: #9ca3af
" coords="srgb.r"></color-scale>
```