### PR TITLE
[color-charts] Fix issues with containers

### DIFF
--- a/src/color-chart/color-chart-global.css
+++ b/src/color-chart/color-chart-global.css
@@ -1,4 +1,6 @@
 color-chart {
+	display: block;
+	height: clamp(0em, 20em, 100vh);
 	contain: size;
 	container-name: chart;
 	container-type: size;

--- a/src/color-chart/color-chart.css
+++ b/src/color-chart/color-chart.css
@@ -1,7 +1,7 @@
 #chart {
 	position: relative;
 	border: 1px solid gray;
-	min-height: 200px;
+	min-height: 100%;
 	container-name: chart;
 	container-type: inline-size;
 }


### PR DESCRIPTION
- Chart containers should have a `display` type respecting height
- Their height should be specified explicitly: `clamp()` works if `0`, as the minimum value, has units; `aspect-ratio` also works
- The previous steps allow container query units (`cqw`, `cqh`) to work as they should