### PR TITLE
[color-chart] Place the Y-axis underneath a tooltip with the value

### DIFF
--- a/src/color-chart/color-chart.css
+++ b/src/color-chart/color-chart.css
@@ -73,6 +73,9 @@
 	container-name: chart;
 	container-type: inline-size;
 
+	&:hover ~ #y_axis {
+		z-index: -1;
+	}
 }
 
 #chart {


### PR DESCRIPTION
...when the chart container is hovered.

I tried another approach, but I couldn't get the shadow DOM boundaries to style the axis based on the state of an element in the light DOM. I also tried creating a new stacking context for the tooltip with `isolation: isolate` without luck.

Without the fix, we might end up with the following:

<img width="300" alt="SCR-20240618-kukd" src="https://github.com/color-js/elements/assets/9166277/a9a07ecb-86aa-4124-9956-f09f24f5366b">


With the fix, we have this:

<img width="300" alt="SCR-20240618-kvay" src="https://github.com/color-js/elements/assets/9166277/12c42ca0-01cf-40ef-8f84-2e95b89d5692">
