### PR TITLE
[color-chart] Don't show points tooltips on hovering the line

### DIFF
--- a/src/color-chart/color-chart-global.css
+++ b/src/color-chart/color-chart-global.css
@@ -74,6 +74,9 @@ color-chart > color-scale {
 			/* if delta y is negative, this needs to rotate the other way */
 			rotate: calc(-1 * var(--delta-y-sign) * var(--angle));
 			background: linear-gradient(to right, var(--color), var(--next-color));
+
+			/* Don't show points tooltips on hovering the line */
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
For now, when we hover a line between two points, the tooltip for the left one is shown (even when we are close enough to the right point of the two):

<img width="994" alt="image" src="https://github.com/color-js/elements/assets/9166277/61aa623f-0238-4a87-9d75-1e7fc21bb086">


To my mind (and expectations), we should only show tooltips on points hover. This PR should fix it.