### PR TITLE
Change the chart container type

### DIFF
--- a/src/color-chart/color-chart.css
+++ b/src/color-chart/color-chart.css
@@ -71,8 +71,7 @@
 
 #chart-container {
 	container-name: chart;
-	container-type: inline-size;
-
+	container-type: size;
 }
 
 #chart {


### PR DESCRIPTION
Otherwise, the `cqh` CQ unit doesn't work, which leads to the wrong placement of data points on the chart.