### PR TITLE
Show the swatch info if one is provided

### DIFF
--- a/src/color-chart/color-chart-global.css
+++ b/src/color-chart/color-chart-global.css
@@ -80,11 +80,7 @@ color-chart > color-scale {
 		}
 	}
 
-	&::part(info) {
-		display: none;
-		background: white;
-		position: absolute;
-	}
+	&::part(info) {}
 
 	&::part(swatch) {
 		min-block-size: 0;


### PR DESCRIPTION
Authors can hide it at any time by adding this rule to their style sheet:
`color-scale::part(info) { display: none; }`