### PR TITLE
[color-chart] Add support for the `info` prop

### DIFF
--- a/src/color-chart/README.md
+++ b/src/color-chart/README.md
@@ -39,6 +39,20 @@ You can also specify a whole label, and if it contains a number, the number will
 
 _(Colors courtesy of Tailwind)_
 
+### The `info` attribute
+
+You can use the `info` attribute to show information about the color scale points. Currently, the only type of information supported is color coords (in any color space), but more will be added in the future.
+
+The format of this attribute is analogous to the one of [`<color-swatch>`](../color-swatch/#the-info-attribute).
+
+```html
+<color-chart y="oklch.c" info="L: oklch.l, C: oklch.c, H: oklch.h">
+	<color-scale colors="50: #eff6ff, 100: #dbeafe, 200: #bfdbfe, 300: #93c5fd, 400: #60a5fa, 500: #3b82f6, 600: #2563eb, 700: #1d4ed8, 800: #1e40af, 900: #1e3a8a, 950: #172554"></color-scale>
+	<color-scale colors="50: #ecfeff, 100: #cffafe, 200: #a5f3fc, 300: #67e8f9, 400: #22d3ee, 500: #06b6d4, 600: #0891b2, 700: #0e7490, 800: #155e75, 900: #164e63, 950: #083344"></color-scale>
+	<color-scale colors="50: #f0fdfa, 100: #ccfbf1, 200: #99f6e4, 300: #5eead4, 400: #2dd4bf, 500: #14b8a6, 600: #0d9488, 700: #0f766e, 800: #115e59, 900: #134e4a, 950: #042f2e"></color-scale>
+</color-chart>
+```
+
 Reactivity:
 
 ```html
@@ -64,6 +78,7 @@ Reactivity:
 |-----------|----------|---------------|---------------|-------------|
 | `x` | `x` | `string` | `null` | The coord to plot on the X axis, if any |
 | `y` | `y` | `string` | `"oklch.l"` | The coord to plot on the Y axis, if any |
+| `info` | `info` | `string` | - | Comma-separated list of coords of the color point to be shown. |
 
 ### Events
 

--- a/src/color-chart/color-chart.js
+++ b/src/color-chart/color-chart.js
@@ -178,6 +178,12 @@ const Self = class ColorChart extends NudeElement {
 			// Re-render swatches
 			this.render(evt);
 		}
+
+		if (name === "info") {
+			for (let colorScale of this.children) {
+				colorScale.info = this.info;
+			}
+		}
 	}
 
 	static props = {
@@ -198,6 +204,8 @@ const Self = class ColorChart extends NudeElement {
 				return this.yResolved.space;
 			},
 		},
+
+		info: {},
 	};
 };
 


### PR DESCRIPTION
Demo: https://deploy-preview-116--color-elements.netlify.app/src/color-chart/#the-info-attribute