### PR TITLE
[color-swatch] Add the `colorInfo` prop

### DIFF
--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -115,8 +115,8 @@ const Self = class ColorSwatch extends ColorElement {
 			this.style.setProperty("--color", colorString);
 		}
 
-		if (name === "info" || name === "color") {
-			if (!this.info.length) {
+		if (name === "colorInfo") {
+			if (!this.colorInfo) {
 				return;
 			}
 
@@ -125,17 +125,8 @@ const Self = class ColorSwatch extends ColorElement {
 				this._el.colorWrapper.after(this._el.info);
 			}
 
-			let info = [];
-			for (let coord of this.info) {
-				let [label, channel] = Object.entries(coord)[0];
-
-				let value = this.color.get(channel);
-				value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
-
-				info.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
-			}
-
-			this._el.info.innerHTML = info.join("\n");
+			let html = Object.entries(this.colorInfo).map(([label, value]) => `<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
+			this._el.info.innerHTML = html.join("\n");
 		}
 	}
 
@@ -188,6 +179,24 @@ const Self = class ColorSwatch extends ColorElement {
 				from: true,
 			},
 			dependencies: ["color"],
+		},
+		colorInfo: {
+			get () {
+				if (!this.info.length || !this.color) {
+					return;
+				}
+
+				let ret = {};
+				for (let coord of this.info) {
+					let [label, channel] = Object.entries(coord)[0];
+
+					let value = this.color.get(channel);
+					value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
+					ret[label] = value;
+				}
+
+				return ret;
+			},
 		},
 	};
 

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -125,7 +125,7 @@ const Self = class ColorSwatch extends ColorElement {
 				this._el.colorWrapper.after(this._el.info);
 			}
 
-			let html = Object.entries(this.colorInfo).map(([label, value]) => `<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
+			let html = Object.entries(this.colorInfo).map(([key, value]) => `<div class="coord"><dt>${ this.infoLabels[key] }</dt><dd>${ value }</dd></div>`);
 			this._el.info.innerHTML = html.join("\n");
 		}
 	}
@@ -180,6 +180,17 @@ const Self = class ColorSwatch extends ColorElement {
 			},
 			dependencies: ["color"],
 		},
+		infoLabels: {
+			get () {
+				let labels = {};
+				for (let data of this.info) {
+					let [label, channel] = Object.entries(data)[0];
+					labels[channel] = label;
+				}
+
+				return labels;
+			},
+		},
 		colorInfo: {
 			get () {
 				if (!this.info.length || !this.color) {
@@ -192,7 +203,7 @@ const Self = class ColorSwatch extends ColorElement {
 
 					let value = this.color.get(channel);
 					value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
-					ret[label] = value;
+					ret[channel] = value;
 				}
 
 				return ret;

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -125,8 +125,17 @@ const Self = class ColorSwatch extends ColorElement {
 				this._el.colorWrapper.after(this._el.info);
 			}
 
-			let html = Object.entries(this.colorInfo).map(([key, value]) => `<div class="coord"><dt>${ this.infoLabels[key] }</dt><dd>${ value }</dd></div>`);
-			this._el.info.innerHTML = html.join("\n");
+			let info = [];
+			for (let coord of this.info) {
+				let [label, channel] = Object.entries(coord)[0];
+
+				let value = this.color.get(channel);
+				value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
+
+				info.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
+			}
+
+			this._el.info.innerHTML = info.join("\n");
 		}
 	}
 
@@ -179,17 +188,6 @@ const Self = class ColorSwatch extends ColorElement {
 				from: true,
 			},
 			dependencies: ["color"],
-		},
-		infoLabels: {
-			get () {
-				let labels = {};
-				for (let data of this.info) {
-					let [label, channel] = Object.entries(data)[0];
-					labels[channel] = label;
-				}
-
-				return labels;
-			},
 		},
 		colorInfo: {
 			get () {

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -129,7 +129,7 @@ const Self = class ColorSwatch extends ColorElement {
 			for (let coord of this.info) {
 				let [label, channel] = Object.entries(coord)[0];
 
-				let value = this.color.get(channel);
+				let value = this.colorInfo[channel];
 				value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
 
 				info.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -130,6 +130,10 @@ const Self = class ColorSwatch extends ColorElement {
 				let [label, channel] = Object.entries(coord)[0];
 
 				let value = this.colorInfo[channel];
+				if (value === undefined) {
+					continue;
+				}
+
 				value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
 
 				info.push(`<div class="coord"><dt>${ label }</dt><dd>${ value }</dd></div>`);
@@ -198,8 +202,12 @@ const Self = class ColorSwatch extends ColorElement {
 				let ret = {};
 				for (let coord of this.info) {
 					let [label, channel] = Object.entries(coord)[0];
-
-					ret[channel] = this.color.get(channel);
+					try {
+						ret[channel] = this.color.get(channel);
+					}
+					catch (e) {
+						console.error(e);
+					}
 				}
 
 				return ret;

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -199,9 +199,7 @@ const Self = class ColorSwatch extends ColorElement {
 				for (let coord of this.info) {
 					let [label, channel] = Object.entries(coord)[0];
 
-					let value = this.color.get(channel);
-					value = typeof value === "number" ? Number(value.toPrecision(4)) : value;
-					ret[channel] = value;
+					ret[channel] = this.color.get(channel);
 				}
 
 				return ret;


### PR DESCRIPTION
As we discussed in #96, the color info is also helpful to get programmatically. This PR addresses this. Under the hood, [the data structure suggested by @LeaVerou (Option 1)](https://github.com/color-js/elements/pull/96#issuecomment-2173355441) is used.

This PR is the first step to implementing deltas and contrast and is intended to check if I got the main idea shaped in the PR mentioned right. The existing API is the same, so it's not a breaking change. Everything still works as before.

The gist of what this PR introduces can be seen in the screenshot (`<color-swatch>` is a Lego block for color charts):

<img width="1009" alt="SCR-20241011-peso" src="https://github.com/user-attachments/assets/02a98fb3-edc4-41ee-9353-8842039391b1">
