### PR TITLE
[color-chart] Correctly plot colors without labels, fixes #103

### DIFF
--- a/src/color-chart/README.md
+++ b/src/color-chart/README.md
@@ -10,7 +10,7 @@ Display lists of colors as a scatterplot or line chart.
 
 ### Basic usage
 
-Plotting a single color scale (buggy order, see [#103](https://github.com/color-js/elements/issues/103)):
+Plotting a single color scale:
 
 ```html
 <color-chart y="oklch.l">

--- a/src/color-chart/color-chart.js
+++ b/src/color-chart/color-chart.js
@@ -129,7 +129,7 @@ const Self = class ColorChart extends ColorElement {
 			ret.colors[index] = color = color.to(this.space);
 			ret.swatches.set(color, swatch);
 
-			let x = name.match(/-?\d*\.?\d+$/)?.[0];
+			let x = name.match(/(?:^|\s)-?\d*\.?\d+$/)?.[0];
 			if (x !== undefined) {
 				// Transform `Label / X-coord` to `Label`
 				// (there should be at least one space before and after the slash so the number is treated as an X-coord)

--- a/src/color-chart/color-chart.js
+++ b/src/color-chart/color-chart.js
@@ -129,6 +129,11 @@ const Self = class ColorChart extends ColorElement {
 			ret.colors[index] = color = color.to(this.space);
 			ret.swatches.set(color, swatch);
 
+			// It's not always possible to use the last number in the color label as the X-coord;
+			// for example, the number “9” can't be interpreted as the X-coord in the “#90caf9” label.
+			// It might cause bugs with color order (see https://github.com/color-js/elements/issues/103).
+			// We expect the valid X-coord to be the only number in the color label (e.g., 50)
+			// or separated from the previous text with a space (e.g., Red 50 or Red / 50).
 			let x = name.match(/(?:^|\s)-?\d*\.?\d+$/)?.[0];
 			if (x !== undefined) {
 				// Transform `Label / X-coord` to `Label`


### PR DESCRIPTION
The main idea behind the fix is that we are not interested in using _any_ number on the default label as the X-coord. Such a number _must_ be specified as a coord: either it's the only number in the color label or detached from the previous text with a space.

<img width="998" alt="image" src="https://github.com/user-attachments/assets/25b188c9-4564-4a92-a1e5-152597108454">

Live preview: https://deploy-preview-133--color-elements.netlify.app/src/color-chart/
