### PR TITLE
Make the website more performant

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,11 +4,6 @@ import "https://colorjs.io/assets/js/colors.js";
 import { styleCallouts } from "https://colorjs.io/assets/js/enhance.js";
 styleCallouts();
 
-let root = document.documentElement;
-document.addEventListener("scroll", evt => {
-	root.style.setProperty("--scrolltop", root.scrollTop);
-}, {passive: true});
-
 import HTMLDemoElement from "https://nudeui.com/elements/html-demo/html-demo.js";
 
 if (document.body.classList.contains("component-page")) {


### PR DESCRIPTION
Remove the `scroll` event listener (it came from the Color.js website, where we now use [a different approach to position the menu](https://github.com/color-js/color.js/commit/a078a420480107d0e948030ab8264944ba8d0ecc)).