### PR TITLE
[gamut-badge] Use contrast text color

### DIFF
--- a/src/gamut-badge/gamut-badge.css
+++ b/src/gamut-badge/gamut-badge.css
@@ -36,6 +36,7 @@
 	align-items: center;
 	justify-content: center;
 	border-radius: .2em;
+	color: white;
 	background-color: var(--color);
 	font-weight: bold;
 	padding-inline: .4em;

--- a/src/gamut-badge/gamut-badge.css
+++ b/src/gamut-badge/gamut-badge.css
@@ -36,11 +36,14 @@
 	align-items: center;
 	justify-content: center;
 	border-radius: .2em;
-	color: white;
 	background-color: var(--color);
 	font-weight: bold;
 	padding-inline: .4em;
 	line-height: 1.4;
+
+	/* See https://lea.verou.me/blog/2024/contrast-color/ */
+	--l: clamp(0, (l / var(--l-threshold, 0.7) - 1) * -infinity, 1);
+	color: oklch(from var(--color) var(--l) 0 h);
 }
 
 :host([gamut="none"]) {


### PR DESCRIPTION
See https://lea.verou.me/blog/2024/contrast-color/

Text on the badges is now readable:

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/fdafe128-7927-4642-b4b2-e1bcee94f3d0">
