### PR TITLE
[channel-slider] First stab at working on #154

### DIFF
--- a/src/channel-slider/channel-slider.css
+++ b/src/channel-slider/channel-slider.css
@@ -1,12 +1,14 @@
 .color-slider-label {
+	--_transition-duration: var(--transition-duration, 200ms);
+
 	display: grid;
 	grid-template-columns: 1fr auto;
 	gap: .3em;
-	position: relative;
+	align-items: center;
 
 	em {
 		opacity: 60%;
-		transition: opacity .2s;
+		transition: opacity var(--_transition-duration);
 	}
 
 	&:not(:hover, :focus-within) em {
@@ -14,34 +16,45 @@
 	}
 
 	input[type=number] {
+		--_border-color: var(--border-color, color-mix(in oklab, currentcolor calc(var(--_current-color-percent, 30) * 1%), oklab(none none none / 0%)));
+
 		all: unset;
 
 		--content-width: calc(var(--value-length) * 1ch);
 		width: calc(var(--content-width, 2ch) + 1.2em);
 		min-width: calc(2ch + 1.2em);
 		box-sizing: content-box;
-		margin-inline-end: -1.2em; /* align the value to the right edge of the slider */
+		padding: .1em .2em;
+		border-radius: .2em;
+		border: 1px solid var(--_border-color);
+		text-align: center;
+		font-size: 90%;
+		transition: var(--_transition-duration) allow-discrete;
+		transition-property: opacity, border-color, display;
 
 		&::-webkit-textfield-decoration-container {
 			gap: .2em;
 		}
 
 		&:not(:hover, :focus) {
+			--_current-color-percent: 10;
+
 			opacity: 60%;
+			border-color: var(--_border-color);
 
 			/* Hide spin buttons in Firefox */
 			appearance: textfield;
 
-			/* Hide spin buttons in Safari */
+			/* Hide spin buttons in Safari and Chrome */
 			&::-webkit-inner-spin-button {
 				opacity: 0;
+				display: none;
 			}
 		}
 
 		@supports (field-sizing: content) {
 			field-sizing: content;
 			width: auto;
-			margin-inline-end: -.9em;
 		}
 	}
 }

--- a/src/channel-slider/channel-slider.css
+++ b/src/channel-slider/channel-slider.css
@@ -6,14 +6,46 @@
 
 	em {
 		opacity: 60%;
+		transition: opacity .2s;
+	}
+
+	&:not(:hover, :focus-within) em {
+		opacity: 0;
+	}
+
+	input[type=number] {
+		all: unset;
+
+		--content-width: calc(var(--value-length) * 1ch);
+		width: calc(var(--content-width, 2ch) + 1.2em);
+		min-width: calc(2ch + 1.2em);
+		box-sizing: content-box;
+		margin-inline-end: -1.2em; /* align the value to the right edge of the slider */
+
+		&::-webkit-textfield-decoration-container {
+			gap: .2em;
+		}
+
+		&:not(:hover, :focus) {
+			opacity: 60%;
+
+			/* Hide spin buttons in Firefox */
+			appearance: textfield;
+
+			/* Hide spin buttons in Safari */
+			&::-webkit-inner-spin-button {
+				opacity: 0;
+			}
+		}
+
+		@supports (field-sizing: content) {
+			field-sizing: content;
+			width: auto;
+			margin-inline-end: -.9em;
+		}
 	}
 }
 
 color-slider {
 	grid-column: 1 / -1;
 }
-
-
-
-
-


### PR DESCRIPTION
- The channel range is moved to the right (to the channel label) and is hidden until the slider is hovered or some of its components have focus.
- The current slider value is at the right part of the slider label and is dimmed until the slider is hovered or the value is focused. The tooltip is removed (or do we need to have it too?)

It looks like this:
<img width="982" alt="image" src="https://github.com/user-attachments/assets/5b01faaf-9ba9-4810-bd80-989f22dc95de">

In the context of `<color-picker>`, it looks like this:
<img width="986" alt="image" src="https://github.com/user-attachments/assets/961fc7a8-c0c4-4bad-b46e-ca9c34c0b245">

One thing that bothers me is that the spin buttons are outside of the slider (if we want the value is aligned to the right of the slider):
<img width="982" alt="image" src="https://github.com/user-attachments/assets/e64f5693-4306-40dd-ac6b-27ee3ad3425d">

Or is it worth applying `&::-webkit-textfield-decoration-container { flex-flow: row-reverse; }` to place the spin buttons to the left of the number? I'm afraid it might confuse users, though. But I'm not sure.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/159bdce1-6939-4b4f-a5a6-413bfb5ba05a">

Or simply don't align the value to the right:

<img width="984" alt="image" src="https://github.com/user-attachments/assets/968a1ce6-1a83-4934-8c57-45820dc9ca66">
<img width="984" alt="image" src="https://github.com/user-attachments/assets/727ff5f2-12e9-48aa-b001-0ce7c9140746">



Live preview: https://deploy-preview-160--color-elements.netlify.app/src/channel-slider/
