### PR TITLE
[channel-slider] Show the spin buttons all the time

### DIFF
--- a/src/channel-slider/channel-slider.css
+++ b/src/channel-slider/channel-slider.css
@@ -45,6 +45,7 @@
 			&::-webkit-inner-spin-button {
 				/* Fade out the spin buttons in Chrome and Safari */
 				opacity: .35;
+				filter: contrast(2);
 			}
 		}
 

--- a/src/channel-slider/channel-slider.css
+++ b/src/channel-slider/channel-slider.css
@@ -30,7 +30,7 @@
 		text-align: center;
 		font-size: 90%;
 		transition: var(--_transition-duration) allow-discrete;
-		transition-property: opacity, border-color, display;
+		transition-property: opacity, border-color;
 
 		&::-webkit-textfield-decoration-container {
 			gap: .2em;
@@ -42,13 +42,9 @@
 			opacity: 60%;
 			border-color: var(--_border-color);
 
-			/* Hide spin buttons in Firefox */
-			appearance: textfield;
-
-			/* Hide spin buttons in Safari and Chrome */
 			&::-webkit-inner-spin-button {
-				opacity: 0;
-				display: none;
+				/* Fade out the spin buttons in Chrome and Safari */
+				opacity: .35;
 			}
 		}
 


### PR DESCRIPTION
But make them subtly until the user interacts with them.

**Not focused (hovered)**
<img width="982" alt="image" src="https://github.com/user-attachments/assets/aec025c3-9e23-47cb-9801-7f06fb896106">

**Focused**
<img width="983" alt="image" src="https://github.com/user-attachments/assets/6568e6d5-97cf-4f55-ac7a-32dfeeb678b7">

Unfortunately, we are a bit tight with options here (except lowering `opacity` or applying filters, as far as I'm aware). But from my perspective, filters are a bit too much in this case.