### PR TITLE
[color-swatch] Add support for the `label` prop, closes #107

### DIFF
--- a/src/color-swatch/README.md
+++ b/src/color-swatch/README.md
@@ -128,6 +128,64 @@ future_swatch_container.append(swatch);
 </script>
 ```
 
+### The `label` attribute
+
+You can provide the color label via the `label` attribute.
+
+<table>
+<thead>
+	<tr>
+		<th></th>
+		<th>Default</th>
+		<th>Large</th>
+	</tr>
+</thead>
+<tbody>
+<tr>
+<th>Static</th>
+<td>
+
+```html
+<color-swatch label="Turquoise">oklch(65% 0.15 210)</color-swatch>
+```
+</td>
+<td>
+
+```html
+<color-swatch label="Turquoise" size="large">oklch(65% 0.15 210)</color-swatch>
+```
+</td>
+</tr>
+<tr>
+<th>Editable</th>
+<td>
+
+```html
+<color-swatch label="Turquoise">
+	<input value="oklch(65% 0.15 210)" />
+</color-swatch>
+```
+</td>
+<td>
+
+```html
+<color-swatch label="Turquoise" size="large">
+	<input value="oklch(65% 0.15 210)" />
+</color-swatch>
+```
+</td>
+</tr>
+</tbody>
+</table>
+
+If the attribute's value matches the element's content, no additional text with the label will be shown.
+
+```html
+<color-swatch label="Turquoise" value="oklch(65% 0.15 210)" size="large">Turquoise</color-swatch>
+```
+
+If used as a property and is not defined via the `label` attribute, its value is that of the element text content.
+
 ### The `info` attribute
 
 You can use the `info` attribute to show information about the color.
@@ -256,6 +314,7 @@ If you don’t, the `<html>` element will be used.
 | `color` | `color` | `Color` &#124; `string` | - | The current color value. |
 | `info` | `info` | `string` | - | Comma-separated list of coords of the current color to be shown. |
 | `value` | `value` | `string` | - | The current value of the swatch. |
+| `label` | `label` | `string` | - | The label of the swatch (e.g., color name). Defaults to the element text content. |
 | `size` | - | `large` | - | The size of the swatch. Currently, it is used only to make a large swatch. |
 | `property` | `property` | `string` | - | CSS property to bind to. |
 | `scope` | `scope` | `string` | `:root` | CSS selector to use as the scope for the specified CSS property. |
@@ -286,6 +345,7 @@ These properties are read-only.
 |------|-------------|
 | `swatch` | The swatch used to render the color. |
 | `details` | Wrapper around all non-swatch content (color name, info, etc) |
+| `label` | The label of the swatch |
 | `color-wrapper` | Wrapper around the color name itself |
 | `gamut` | Gamut indicator |
 | `info` | Any info generateed by the `info` attribute |

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -16,6 +16,7 @@ const Self = class ColorSwatch extends ColorElement {
 		</slot>
 		<div id="wrapper" part="details">
 			<slot name="before"></slot>
+			<div part="label"></div>
 			<div part="color">
 				<slot></slot>
 			</div>
@@ -27,6 +28,7 @@ const Self = class ColorSwatch extends ColorElement {
 
 		this._el = {
 			wrapper: this.shadowRoot.querySelector("#wrapper"),
+			label: this.shadowRoot.querySelector("[part=label]"),
 			colorWrapper: this.shadowRoot.querySelector("[part=color]"),
 		};
 
@@ -59,6 +61,11 @@ const Self = class ColorSwatch extends ColorElement {
 
 	get gamut () {
 		return this._el.gamutIndicator.gamut;
+	}
+
+	get textContent () {
+		// Children that are not assigned to another slot
+		return [...this.childNodes].filter(n => !n.slot).map(n => n.textContent).join("").trim();
 	}
 
 	propChangedCallback ({name, prop, detail: change}) {
@@ -98,6 +105,15 @@ const Self = class ColorSwatch extends ColorElement {
 		if (name === "value") {
 			if (input && (!input.value || input.value !== this.value)) {
 				input.value = this.value;
+			}
+		}
+
+		if (name === "label") {
+			if (this.label.length && this.label !== this.textContent) {
+				this._el.label.textContent = this.label;
+			}
+			else {
+				this._el.label.textContent = "";
 			}
 		}
 
@@ -155,11 +171,19 @@ const Self = class ColorSwatch extends ColorElement {
 					return this._el.input.value;
 				}
 
-				// Children that are not assigned to another slot
-				return [...this.childNodes].filter(n => !n.slot).map(n => n.textContent).join("").trim();
+				return this.textContent;
 			},
 			reflect: {
 				from: true,
+			},
+		},
+		label: {
+			type: String,
+			default () {
+				return this.textContent;
+			},
+			convert (value) {
+				return value.trim();
 			},
 		},
 		color: {


### PR DESCRIPTION
#107 seems to be a blocking issue for #167, so let's try to address it first.

This PR adds the `label` prop to `<color-swatch>` and the corresponding part for custom styling. As @LeaVerou suggested in #107, the implementation is inspired by the `<option>` element.

There is no separate slot for the value of this attribute because I couldn't think of any use cases where it might be needed (I might miss something, though).

Live preview: https://deploy-preview-171--color-elements.netlify.app/src/color-swatch/#the-label-attribute