### PR TITLE
[space-picker] Add the `getSpaceLabel()` prop

### DIFF
--- a/src/space-picker/README.md
+++ b/src/space-picker/README.md
@@ -93,7 +93,7 @@ All properties are reactive and can be set programmatically:
 | `value`   | `value`   | `string`                            | The first color space in `this.spaces`. | The current value of the picker.                                                                          |
 | `spaces`  | `spaces`  | `string` &#124; `Array<ColorSpace>` | All known color spaces.                 | Comma-separated list of color spaces to use.                                                              |
 | —         | `groupBy` | `Function`                          | —                                       | Function to group the color spaces. Takes a color space object as an argument and returns the group name. |
-| – | `getSpaceLabel` | `Function` | – | Function to get the label for a color space. Takes a color space object as an argument and returns its label. |
+| – | `getSpaceLabel` | `Function` | `space => space.name` | Function to get the label for a color space. Takes a color space object as an argument and returns its label. |
 
 ### Getters
 

--- a/src/space-picker/README.md
+++ b/src/space-picker/README.md
@@ -25,6 +25,20 @@ Unknown color spaces also work:
 <space-picker spaces="bar, oklch, p3, srgb, foo" value="foo"></space-picker>
 ```
 
+### Custom labels
+
+Do you need the picker to show something other than the default color space names, such as color space ids?
+Simply define the `getSpaceLabel()` method on the picker instance, and you are done.
+The method takes a color space object as an argument and returns a string that will be used as the space label.
+
+```html
+<space-picker id="custom_labels"></space-picker>
+
+<script>
+    custom_labels.getSpaceLabel = space => space.id;
+</script>
+```
+
 ### Grouping the color spaces
 
 You can group the color spaces the way you like by specifying the `groupBy` property. Its value is a function
@@ -79,6 +93,7 @@ All properties are reactive and can be set programmatically:
 | `value`   | `value`   | `string`                            | The first color space in `this.spaces`. | The current value of the picker.                                                                          |
 | `spaces`  | `spaces`  | `string` &#124; `Array<ColorSpace>` | All known color spaces.                 | Comma-separated list of color spaces to use.                                                              |
 | —         | `groupBy` | `Function`                          | —                                       | Function to group the color spaces. Takes a color space object as an argument and returns the group name. |
+| – | `getSpaceLabel` | `Function` | – | Function to get the label for a color space. Takes a color space object as an argument and returns its label. |
 
 ### Getters
 

--- a/src/space-picker/space-picker.js
+++ b/src/space-picker/space-picker.js
@@ -33,7 +33,7 @@ const Self = class SpacePicker extends ColorElement {
 		if (name === "spaces") {
 			if (!this.groups) {
 				this._el.picker.innerHTML = Object.entries(this.spaces)
-					.map(([id, space]) => `<option label="${ this.getSpaceLabel(space) }" value="${ id }">${ space.name }</option>`)
+					.map(([id, space]) => `<option value="${ id }">${ this.getSpaceLabel(space) }</option>`)
 					.join("\n");
 			}
 			else {
@@ -57,7 +57,7 @@ const Self = class SpacePicker extends ColorElement {
 				this._el.picker.innerHTML = groups.map(([type, spaces]) => `
 					<optgroup label="${type}">
 						${Object.entries(spaces)
-							.map(([id, space]) => `<option label="${ this.getSpaceLabel(space) }" value="${ id }">${ space.name }</option>`)
+							.map(([id, space]) => `<option value="${ id }">${ this.getSpaceLabel(space) }</option>`)
 							.join("\n")}
 					</optgroup>
 				`).join("\n");

--- a/src/space-picker/space-picker.js
+++ b/src/space-picker/space-picker.js
@@ -33,7 +33,7 @@ const Self = class SpacePicker extends ColorElement {
 		if (name === "spaces") {
 			if (!this.groups) {
 				this._el.picker.innerHTML = Object.entries(this.spaces)
-					.map(([id, space]) => `<option value="${id}">${space.name}</option>`)
+					.map(([id, space]) => `<option label="${ this.getSpaceLabel?.(space) ?? space.name }" value="${ id }">${ space.name }</option>`)
 					.join("\n");
 			}
 			else {
@@ -57,7 +57,7 @@ const Self = class SpacePicker extends ColorElement {
 				this._el.picker.innerHTML = groups.map(([type, spaces]) => `
 					<optgroup label="${type}">
 						${Object.entries(spaces)
-							.map(([id, space]) => `<option value="${id}">${space.name}</option>`)
+							.map(([id, space]) => `<option label="${ this.getSpaceLabel?.(space) ?? space.name }" value="${ id }">${ space.name }</option>`)
 							.join("\n")}
 					</optgroup>
 				`).join("\n");
@@ -168,6 +168,14 @@ const Self = class SpacePicker extends ColorElement {
 
 				return ret;
 			},
+		},
+
+		getSpaceLabel: {
+			type: {
+				is: Function,
+				arguments: ["space"],
+			},
+			reflect: false,
 		},
 	};
 

--- a/src/space-picker/space-picker.js
+++ b/src/space-picker/space-picker.js
@@ -33,7 +33,7 @@ const Self = class SpacePicker extends ColorElement {
 		if (name === "spaces") {
 			if (!this.groups) {
 				this._el.picker.innerHTML = Object.entries(this.spaces)
-					.map(([id, space]) => `<option label="${ this.getSpaceLabel?.(space) ?? space.name }" value="${ id }">${ space.name }</option>`)
+					.map(([id, space]) => `<option label="${ this.getSpaceLabel(space) }" value="${ id }">${ space.name }</option>`)
 					.join("\n");
 			}
 			else {
@@ -57,7 +57,7 @@ const Self = class SpacePicker extends ColorElement {
 				this._el.picker.innerHTML = groups.map(([type, spaces]) => `
 					<optgroup label="${type}">
 						${Object.entries(spaces)
-							.map(([id, space]) => `<option label="${ this.getSpaceLabel?.(space) ?? space.name }" value="${ id }">${ space.name }</option>`)
+							.map(([id, space]) => `<option label="${ this.getSpaceLabel(space) }" value="${ id }">${ space.name }</option>`)
 							.join("\n")}
 					</optgroup>
 				`).join("\n");
@@ -174,6 +174,9 @@ const Self = class SpacePicker extends ColorElement {
 			type: {
 				is: Function,
 				arguments: ["space"],
+			},
+			default () {
+				return space => space.name;
 			},
 			reflect: false,
 		},


### PR DESCRIPTION
To handle custom color space labels.

Live preview: https://deploy-preview-172--color-elements.netlify.app/src/space-picker/#custom-labels