### PR TITLE
[channel-slider] Add support for the `alpha` channel

### DIFF
--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -25,8 +25,6 @@ The alpha channel is also supported:
 <channel-slider space="oklch" channel="alpha"></channel-slider>
 ```
 
-Warning: Using alpha requires Color.js v0.6.0 or higher.
-
 In most cases you’d also want to set a color to set the other channels and the initial value:
 
 ```html

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -19,6 +19,14 @@ Basic example:
 <channel-slider space="oklch" channel="h"></channel-slider>
 ```
 
+The alpha channel is also supported:
+
+```html
+<channel-slider space="oklch" channel="alpha"></channel-slider>
+```
+
+Warning: Using alpha requires Color.js v0.6.0 or higher.
+
 In most cases you’d also want to set a color to set the other channels and the initial value:
 
 ```html
@@ -81,6 +89,7 @@ All attributes are reactive:
 		<option>l</option>
 		<option>c</option>
 		<option>h</option>
+		<option>alpha</option>
 	</select>
 </label>
 
@@ -90,7 +99,7 @@ All attributes are reactive:
 <script>
 	function fromSlider () {
 		space_select.value = dynamic_slider.space.id;
-		channel_select.innerHTML = Object.keys(dynamic_slider.space.coords).map(c => `<option>${c}</option>`).join('\n');
+		channel_select.innerHTML = [...Object.keys(dynamic_slider.space.coords).map(c => `<option>${c}</option>`), "<option>alpha</option>"].join('\n');
 		channel_select.value = dynamic_slider.channel;
 	}
 

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -203,8 +203,7 @@ const Self = class ChannelSlider extends ColorElement {
 			type: Number,
 			default () {
 				if (this.channel === "alpha") {
-					let value = this.defaultColor.alpha;
-					return value * 100;
+					return this.defaultColor.alpha * 100;
 				}
 				else {
 					return this.defaultColor.get(this.channel);

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -45,7 +45,8 @@ const Self = class ChannelSlider extends ColorElement {
 		let color = this.defaultColor.clone();
 
 		if (this.channel === "alpha") {
-			value /= 100;
+			color.alpha = value / 100;
+			return color;
 		}
 
 		try {

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -21,11 +21,6 @@ const Self = class ChannelSlider extends ColorElement {
 
 		this._el = dom.named(this);
 		this._el.slot = this.shadowRoot.querySelector("slot");
-
-		// Starting from v0.6.0, Color.js supports the alpha channel.
-		// To detect whether we are on v0.6.0 or higher, we can check if color coords are plain number primitives.
-		// This was the change introduced in v0.6.0.
-		this.supportsAlpha = new Self.Color("rgb(none none none)").coords[0] === null;
 	}
 
 	connectedCallback () {
@@ -50,12 +45,7 @@ const Self = class ChannelSlider extends ColorElement {
 		let color = this.defaultColor.clone();
 
 		if (this.channel === "alpha") {
-			if (this.supportsAlpha) {
-				value /= 100;
-			}
-			else {
-				return color;
-			}
+			value /= 100;
 		}
 
 		try {
@@ -123,10 +113,6 @@ const Self = class ChannelSlider extends ColorElement {
 			if (name === "space" || name === "channel" || name === "min" || name === "max") {
 				this._el.channel_info.innerHTML = `${ this.channelName } <em>(${ this.min }&thinsp;&ndash;&thinsp;${ this.max })</em>`;
 			}
-		}
-
-		if (name === "channel" && this.channel === "alpha" && !this.supportsAlpha) {
-			console.warn("Using alpha requires Color.js v0.6.0 or higher.");
 		}
 	}
 
@@ -216,13 +202,8 @@ const Self = class ChannelSlider extends ColorElement {
 			type: Number,
 			default () {
 				if (this.channel === "alpha") {
-					if (this.supportsAlpha) {
-						let value = this.defaultColor.get(this.channel);
-						return value * 100;
-					}
-					else {
-						return 100;
-					}
+					let value = this.defaultColor.alpha;
+					return value * 100;
 				}
 				else {
 					return this.defaultColor.get(this.channel);


### PR DESCRIPTION
It works in every version of Color.js. It's a spin-off of #63 to simplify the process of adding new features.

Preview: https://deploy-preview-173--color-elements.netlify.app/src/channel-slider/