### PR TITLE
[color-picker] Add support for `alpha`, closes #57

### DIFF
--- a/src/color-picker/README.md
+++ b/src/color-picker/README.md
@@ -22,22 +22,10 @@ If no color space or color is provided, the default ones will be used: `oklch` f
 
 ### The `alpha` attribute
 
-Colors with the alpha channel are also supported:
+Colors with the alpha channel are also supported. Add the `alpha` boolean attribute to show the alpha channel:
 
 ```html
-<color-picker space="oklch" color="oklch(60% 30% 180 / .6)"></color-picker>
-```
-
-Add the `alpha` boolean attribute to show the alpha channel permanently:
-
-```html
-<color-picker space="oklch" color="oklch(60% 30% 180)" alpha></color-picker>
-```
-
-Set this attribute to `false` to permanently hide the alpha channel (regardless of the color):
-
-```html
-<color-picker space="oklch" color="oklch(60% 30% 180 / .6)" alpha="false"></color-picker>
+<color-picker space="oklch" color="oklch(60% 30% 180 / 0.6)" alpha></color-picker>
 ```
 
 ### Slots
@@ -139,7 +127,7 @@ All attributes are reactive:
 | `space` | `spaceId` | `string` | `oklch` | The color space to use for interpolation. |
 | – | `space` | `ColorSpace` | `OKLCh` | Color space object corresponding to the `space` attribute. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
-| `alpha` | `alpha` | `boolean` &#124; `undefined` | `undefined` | Whether to show the alpha channel slider or not. If `undefined` and the color has an alpha channel, the slider will be shown regardless. |
+| `alpha` | `alpha` | `boolean` &#124; `undefined` | `undefined` | Whether to show the alpha channel slider or not. |
 
 ### Events
 

--- a/src/color-picker/README.md
+++ b/src/color-picker/README.md
@@ -20,6 +20,26 @@ If no color space or color is provided, the default ones will be used: `oklch` f
 <color-picker></color-picker>
 ```
 
+### The `alpha` attribute
+
+Colors with the alpha channel are also supported:
+
+```html
+<color-picker space="oklch" color="oklch(60% 30% 180 / .6)"></color-picker>
+```
+
+Add the `alpha` boolean attribute to show the alpha channel permanently:
+
+```html
+<color-picker space="oklch" color="oklch(60% 30% 180)" alpha></color-picker>
+```
+
+Set this attribute to `false` to permanently hide the alpha channel (regardless of the color):
+
+```html
+<color-picker space="oklch" color="oklch(60% 30% 180 / .6)" alpha="false"></color-picker>
+```
+
 ### Slots
 
 ```html
@@ -95,6 +115,13 @@ All attributes are reactive:
 </style>
 ```
 
+```html
+<label>
+	<input type="checkbox" onchange="this.parentElement.nextElementSibling.alpha = this.checked" /> Alpha channel
+</label>
+<color-picker></color-picker>
+```
+
 ## Reference
 
 ### Slots
@@ -112,6 +139,7 @@ All attributes are reactive:
 | `space` | `spaceId` | `string` | `oklch` | The color space to use for interpolation. |
 | – | `space` | `ColorSpace` | `OKLCh` | Color space object corresponding to the `space` attribute. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
+| `alpha` | `alpha` | `boolean` &#124; `undefined` | `undefined` | Whether to show the alpha channel slider or not. If `undefined` and the color has an alpha channel, the slider will be shown regardless. |
 
 ### Events
 

--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -62,11 +62,6 @@ const Self = class ColorPicker extends ColorElement {
 				return;
 			}
 			this.color = this._el.swatch.color;
-
-			if (this.color.alpha < 1 && this.alpha === undefined) {
-				// Enable alpha if the color became semi-transparent
-				this.alpha = true;
-			}
 		}
 		else if (this._el.space_picker.contains(source) || this._slots.color_space.assignedElements().includes(source)) {
 			this.spaceId = event.target.value;
@@ -85,7 +80,7 @@ const Self = class ColorPicker extends ColorElement {
 
 			let i = 0;
 			let channels = [...Object.keys(this.space.coords)];
-			if (this.alpha || (this.alpha === undefined && this.color.alpha < 1)) {
+			if (this.alpha) {
 				channels.push("alpha");
 			}
 			for (let channel of channels) {
@@ -118,11 +113,6 @@ const Self = class ColorPicker extends ColorElement {
 			if (!this._el.swatch.color || !this.color.equals(this._el.swatch.color)) {
 				// Avoid typing e.g. "red" and having it replaced with "rgb(100% 0% 0%)" under your caret
 				prop.applyChange(this._el.swatch, change);
-			}
-
-			if (this.color.alpha < 1 && this.alpha === undefined) {
-				// Enable alpha if the color became semi-transparent
-				this.alpha = true;
 			}
 		}
 	}


### PR DESCRIPTION
Related to #173 (and should be merged after it). Works with all versions of Color.js

Docs: https://deploy-preview-174--color-elements.netlify.app/src/color-picker/#the-alpha-attribute