### PR TITLE
[website] Add sidebar with all elements and in-page sections

### DIFF
--- a/_includes/component.njk
+++ b/_includes/component.njk
@@ -25,6 +25,14 @@
 <script src="{{ page | relative }}/index.js" type="module"></script>
 <script src="{{ name }}.js" type="module"></script>
 
+<aside id="toc">
+	<ul>
+	{% for name, description in components -%}
+	<li><a href="{{ page | relative }}/src/{{ name }}/"><code>&lt;{{ name }}&gt;</code></a></li>
+	{% endfor %}
+	</ul>
+</aside>
+
 {{ content | safe }}
 
 <section id="installation">

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,5 +1,6 @@
 import "https://colorjs.io/assets/js//prism.js";
 import "https://colorjs.io/assets/js/colors.js";
+import "https://blissfuljs.com/bliss.shy.js";
 
 import { styleCallouts } from "https://colorjs.io/assets/js/enhance.js";
 styleCallouts();
@@ -8,4 +9,8 @@ import HTMLDemoElement from "https://nudeui.com/elements/html-demo/html-demo.js"
 
 if (document.body.classList.contains("component-page")) {
 	HTMLDemoElement.wrapAll();
+}
+
+if (window.toc) {
+	import("https://colorjs.io/assets/js/docs.js");
 }


### PR DESCRIPTION
Closes #19. Closes #20.

Reuses the code from the Color.js website by maximum:

<img width="1570" alt="image" src="https://github.com/user-attachments/assets/c5ee3adf-86b0-45d3-89c1-726b3afd2cd0">

**Narrow page:**

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/90576a6d-70c1-4d3d-9f4c-a0af6b895584">

