### PR TITLE
Entirely hide elements before they are defined

### DIFF
--- a/src/common/color-element.js
+++ b/src/common/color-element.js
@@ -39,7 +39,7 @@ const Self = class ColorElement extends NudeElement {
 		// Hide elements before they are defined
 		let style = document.getElementById("color-element-styles")
 		          ?? Object.assign(document.createElement("style"), {id: "color-element-styles"});
-		style.textContent = `:is(${ colorTags.join(", ") }):not(:defined) {display: none}`;
+		style.textContent = `:is(${ colorTags.join(", ") }):is(:not(:defined), :not(:defined) *) {opacity: 0}`;
 		if (!style.parentNode) {
 			document.head.append(style);
 		}


### PR DESCRIPTION
We should hide not only the element itself but all its descendants in the Light DOM (crucial for `<color-chart>`s).

I went with `opacity: 0` instead of `display: none` because it seems to cause less layout shift.