### PR TITLE
[website] Fix horizontal scrolling on pages with tables

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -77,6 +77,25 @@
 	}
 }
 
+.scrollable {
+	--_transparent-canvas: color-mix(in oklab, canvas, oklab(none none none / 0%) 100%);
+	--_hint-color: color-mix(in oklab, canvastext 30%, var(--_transparent-canvas));
+
+	max-inline-size: 100%;
+	overflow-x: auto;
+
+	/**
+	* Scrolling hints (https://lea.verou.me/2012/04/background-attachment-local/)
+	*/
+
+	background: linear-gradient(to right, canvas 1em, var(--_transparent-canvas)) left / 3em 100%,
+	            linear-gradient(to right, var(--_hint-color), var(--_transparent-canvas) 70%) left / 1em 100%,
+	            linear-gradient(to left, canvas 1em, var(--_transparent-canvas)) right / 3em 100%,
+	            linear-gradient(to left, var(--_hint-color), var(--_transparent-canvas) 70%) right / 1em 100%;
+	background-repeat: no-repeat;
+	background-attachment: local, scroll, local, scroll;
+}
+
 /* Tables with demos */
 table:has(html-demo) {
 	display: grid;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -76,3 +76,58 @@
 		}
 	}
 }
+
+/* Tables with demos */
+table:has(html-demo) {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr);
+
+	thead,
+	tbody,
+	tfoot,
+	tr {
+		display: contents;
+	}
+
+	@media (width < 950px) {
+		/* Visually hide column headings on small screens */
+		thead th {
+			position: absolute;
+			left: -10000px;
+			top: auto;
+			width: 1px;
+			height: 1px;
+			overflow: hidden;
+		}
+
+		:is(&, & th, & td) {
+			border: none;
+			background-color: transparent;
+		}
+	}
+
+	@media (width >= 950px) {
+		&:has(tbody > tr:first-of-type > td:last-child:nth-child(2)) {
+			/* Table has two columns */
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		&:has(tbody > tr:first-of-type > td:last-child:nth-child(3)) {
+			/* Table has three columns */
+			grid-template-columns: auto repeat(2, minmax(0, 1fr));
+		}
+
+		thead {
+			display: contents;
+		}
+
+		tbody {
+			th {
+				/* To save space, render row headers vertically */
+				text-align: center;
+				writing-mode: vertical-rl;
+				transform: rotate(.5turn);
+			}
+		}
+	}
+}

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -9,3 +9,11 @@ import HTMLDemoElement from "https://nudeui.com/elements/html-demo/html-demo.js"
 if (document.body.classList.contains("component-page")) {
 	HTMLDemoElement.wrapAll();
 }
+
+// Wrap all tables in a div.scrollable to make them scrollable on small screens
+document.querySelectorAll("table").forEach((table) => {
+	let wrapper = document.createElement("div");
+	wrapper.classList.add("scrollable");
+	table.replaceWith(wrapper);
+	wrapper.append(table);
+});


### PR DESCRIPTION
### Changes
- Use different layouts for tables with examples on smaller screens
- Make big tables scrollable and add scrolling hints for better UX

### Remaining issues

On tiny screens, there still might be overflows, causing horizontal scrolling. Like so:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/ee2eac67-2956-4753-9a89-08732faec433" />

I can think of one fix for this (and already tried it): add `overflow-x: auto` to the slot named `demo` of the `html-demo` element. To do so, we should probably make it a part (and `toolbar` and `code` as well). This change is already a part of the element's roadmap, so it's a planned improvement.

Adding `overflow-x: auto`, though, might cause an issue with the details popup:
<img width="568" alt="image" src="https://github.com/user-attachments/assets/7754880d-9a72-4077-9741-21312e86646e" />

I wonder if we should move [the logic we use in `<color-chart>` to overcome this limitation with `overflow`](https://github.com/color-js/elements/blob/832c1abe895500235740efdb99b80e04fdaade38/src/color-chart/color-chart.js#L191-L208) to the `<color-swatch>` element itself and handle it there? In that case, the issue will be fixed in `<color-swatch>` and `<color-chart>`.