### PR TITLE
[color-swatch][color-scale] Fix layout issues when there are many color swatches

### DIFF
--- a/src/color-scale/color-scale.css
+++ b/src/color-scale/color-scale.css
@@ -1,26 +1,21 @@
 :host {
+	display: grid;
 	gap: .3em;
+	grid-auto-flow: row;
+	grid-template-rows: auto auto;
+	grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
 }
 
 #swatches {
-	display: flex;
-	gap: inherit;
+	display: contents;
 }
 
 color-swatch {
 	margin: 0;
-	flex: 1;
 }
 
 @supports (grid-template-columns: subgrid) {
 	/* Avoid uneven swatch heights */
-	#swatches {
-		display: grid;
-		grid-auto-flow: row;
-		grid-template-rows: auto auto;
-		grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-	}
-
 	color-swatch {
 		width: 100%;
 		grid-row: 1 / span 2;

--- a/src/color-scale/color-scale.js
+++ b/src/color-scale/color-scale.js
@@ -60,7 +60,7 @@ const Self = class ColorScale extends ColorElement {
 				this.#swatches[i] = swatch = document.createElement("color-swatch");
 				swatch.setAttribute("size", "large");
 				swatch.setAttribute("part", "color-swatch");
-				swatch.setAttribute("exportparts", "swatch, info, gamut");
+				swatch.setAttribute("exportparts", "swatch, info, gamut, label: swatch-label");
 				newSwatches.push(swatch);
 			}
 

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -96,6 +96,9 @@ slot {
 	flex-flow: inherit;
 	gap: inherit;
 
+	/* Prevent flex items from overflowing */
+	min-inline-size: 0;
+
 	&.static {
 		&:is(:host([size="large"]) *) {
 			background: white;
@@ -174,6 +177,12 @@ slot {
 [part="color"] {
 	display: flex;
 	gap: .2em;
+}
+
+[part="label"] {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 slot:not([name]) {

--- a/src/color-swatch/color-swatch.js
+++ b/src/color-swatch/color-swatch.js
@@ -111,9 +111,11 @@ const Self = class ColorSwatch extends ColorElement {
 		if (name === "label") {
 			if (this.label.length && this.label !== this.swatchTextContent) {
 				this._el.label.textContent = this.label;
+				this._el.label.title = this.label;
 			}
 			else {
 				this._el.label.textContent = "";
+				this._el.label.title = "";
 			}
 		}
 


### PR DESCRIPTION
Also, on small devices.

This fix was part of [another PR](#167), but since we don't want it to be held, I extracted it to this one.

~~This fix allows [color palettes](https://palettes.colorjs.io/palettes/) to look a bit better:~~
<img width="1019" alt="image" src="https://github.com/user-attachments/assets/b7f607d0-42b8-455d-b5db-ca39e832c7e5" />

~~However, not all the issues can be fixed. For example, [Subgrid doesn't play well with CQ](https://codepen.io/dmitrysharabin/pen/oNRZzbb) in all (🫣) browsers! That's why we can't get (at least) something like this by merging this PR:~~
<img width="996" alt="image" src="https://github.com/user-attachments/assets/9f4bf25c-0086-4689-b4d3-a702c5798d34" />

I'll try to improve this further, but I just want to ensure we have something to start with.

**UPDATE**

I've come up with another approach I like more: We can apply `text-overflow: ellipsis` to swatch labels on overflow (the full label text can be seen in a tooltip on hover, thanks to the `title` attribute).

<img width="993" alt="image" src="https://github.com/user-attachments/assets/bb40438b-b221-4645-8e8a-4d408f914ea3" />


We also expose it as a `swatch-label` part for alternative styling. For example, one can make the labels scrollable if they like:

```css
color-scale::part(swatch-label) {
	overflow: scroll;
	text-overflow: revert;
	overscroll-behavior: contain;
}
```

<img width="986" alt="image" src="https://github.com/user-attachments/assets/d1530cf4-fbd2-470c-a459-d483a97b6a0f" />
