### PR TITLE
[color-elements] Use `<link>` for shadow styles instead of `@import()`

### DIFF
--- a/src/common/color-element.js
+++ b/src/common/color-element.js
@@ -32,7 +32,7 @@ const Self = class ColorElement extends NudeElement {
 				let url = this.shadowStyle;
 				url = url === true ? `./${this.tagName}.css` : url;
 				url = new URL(url, this.url);
-				this.shadowTemplate = `<style>@import url("${ url }")</style>` + "\n" + this.shadowTemplate;
+				this.shadowTemplate = `<link rel="stylesheet" href="${ url }" />` + "\n" + this.shadowTemplate;
 			}
 		}
 


### PR DESCRIPTION
This is such a performance gain! Even quite heavy color palettes site feels more responsive with this tiny fix. Your proposal, @LeaVerou, worked (I had no doubts that it would). Thank you!

However, we need to release the NudeElement and use it in color elements to see all these gains. I ran all my tests using the dev versions of all our packages.