### PR TITLE
[color-swatch] Avoid overflow

### DIFF
--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -18,7 +18,7 @@
 
 :host([size="large"]) {
 	flex-flow: column;
-	inline-size: 11em;
+	inline-size: min(11em, 100%);
 	min-block-size: 6em;
 	contain: inline-size;
 	container-name: color-swatch;


### PR DESCRIPTION
Specifically when used inside `<color-scale>`s. Fixes the issue with swatches' inline size on the [Research on color palettes website](https://palettes.colorjs.io/).