### PR TITLE
[color-swatch] Fix the details part's compact styles in Safari

### DIFF
--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -171,7 +171,7 @@ slot {
 		 doesn't work in Safari!
 		 See https://bugs.webkit.org/show_bug.cgi?id=296577
 		*/
-		&:not(:host(:hover) *):not(:host(:focus-within) *):not(:host(:active) *):not(:host(:target) *):not(:host([open]) *),
+		&:is(:host(:not(:hover):not(:focus-within):not(:active):not(:target):not([open])) *),
 		&:is(:host([open=false]) *) {
 			display: none;
 			opacity: 0;

--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -165,7 +165,13 @@ slot {
 			clip-path: polygon(0 0, 0 100%, 100% 100%);
 		}
 
-		&:not(:is(:host(:hover), :host(:focus-within), :host(:active), :host(:target), :host([open])) *),
+		/*
+		 More straightforward selector:
+		 &:not(:is(:host(:hover), :host(:focus-within), :host(:active), :host(:target), :host([open])) *)
+		 doesn't work in Safari!
+		 See https://bugs.webkit.org/show_bug.cgi?id=296577
+		*/
+		&:not(:host(:hover) *):not(:host(:focus-within) *):not(:host(:active) *):not(:host(:target) *):not(:host([open]) *),
 		&:is(:host([open=false]) *) {
 			display: none;
 			opacity: 0;


### PR DESCRIPTION
For now, they are not shown on hover.