### PR TITLE
Some more fixes

### DIFF
--- a/src/color-chart/color-chart.js
+++ b/src/color-chart/color-chart.js
@@ -347,7 +347,6 @@ const Self = class ColorChart extends ColorElement {
 		y: {
 			default: "oklch.l",
 			changed (change) {
-				this.bounds.y.min = Infinity;
 				this.bounds.y = { min: Infinity, max: -Infinity };
 			},
 			convert (value) {
@@ -449,8 +448,7 @@ const Self = class ColorChart extends ColorElement {
 		x: {
 			default: null,
 			changed (change) {
-				this.bounds.x.min = Infinity;
-				this.bounds.x.max = -Infinity;
+				this.bounds.x = { min: Infinity, max: -Infinity };
 			},
 		},
 


### PR DESCRIPTION
- Make charts dynamic again (react to changes in color coordinates and axis ranges).

There are still bugs with X-axis styling that need to be fixed, though. However, the main functionality should already be in place. Except `xmin`. Investigating further.

> Except `xmin`. Investigating further.

Actually, it works. It's just that the [`getAxis()`](https://github.com/color-js/elements/blob/2eaa01d0d96692024e8d691d856c6ab7d05cf586/src/color-chart/color-chart.js#L554) method might calculate a range that includes the specified range, but its boundaries are not always the same as the specified ones. For example, for `xmin=0.3` and `xmax=0.9` (when rendering lightness), we might obtain the range `0.2–0.9` as the most suitable one.