### PR TITLE
[color-chart] Make charts look consistent across browsers by default

### DIFF
--- a/src/color-chart/color-chart-global.css
+++ b/src/color-chart/color-chart-global.css
@@ -54,31 +54,34 @@ color-chart > color-scale {
 	}
 
 	/* Lines */
-	@container not style(--color-scale-type: discrete) {
-		&::part(color-swatch)::before {
-			--delta-x: calc(var(--next-x) - var(--x));
-			--delta-y: calc(var(--next-y) - var(--y));
-			--delta-y-abs: max(var(--delta-y), -1 * var(--delta-y));
-			--delta-y-sign: calc(var(--delta-y) / var(--delta-y-abs));
+	&::part(color-swatch)::before {
+		--delta-x: calc(var(--next-x) - var(--x));
+		--delta-y: calc(var(--next-y) - var(--y));
+		--delta-y-abs: max(var(--delta-y), -1 * var(--delta-y));
+		--delta-y-sign: calc(var(--delta-y) / var(--delta-y-abs));
 
-			--width: calc(var(--chart-width) * var(--delta-x) / var(--extent-x));
-			--height: calc(var(--chart-height) * var(--delta-y-abs) / var(--extent-y));
-			--angle: atan2(var(--height), var(--width));
+		--width: calc(var(--chart-width) * var(--delta-x) / var(--extent-x));
+		--height: calc(var(--chart-height) * var(--delta-y-abs) / var(--extent-y));
+		--angle: atan2(var(--height), var(--width));
 
-			content: "";
-			position: absolute;
-			z-index: 1;
-			left: calc(50% - var(--_line-width) / 2);
-			top: calc(50% - var(--_line-width) / 2);
-			width: calc((var(--width) + var(--_line-width)) / cos(var(--angle)));
-			height: var(--_line-width);
-			transform-origin: calc(var(--_line-width) / 2) calc(var(--_line-width) / 2);
-			/* if delta y is negative, this needs to rotate the other way */
-			rotate: calc(-1 * var(--delta-y-sign) * var(--angle));
-			background: linear-gradient(to right, var(--color), var(--next-color));
+		content: "";
+		position: absolute;
+		z-index: 1;
+		left: calc(50% - var(--_line-width) / 2);
+		top: calc(50% - var(--_line-width) / 2);
+		width: calc((var(--width) + var(--_line-width)) / cos(var(--angle)));
+		height: var(--_line-width);
+		transform-origin: calc(var(--_line-width) / 2) calc(var(--_line-width) / 2);
+		/* if delta y is negative, this needs to rotate the other way */
+		rotate: calc(-1 * var(--delta-y-sign) * var(--angle));
+		background: linear-gradient(to right, var(--color), var(--next-color));
 
-			/* Don't show points tooltips on hovering the line */
-			pointer-events: none;
+		/* Don't show points tooltips on hovering the line */
+		pointer-events: none;
+
+		@container style(--color-scale-type: discrete) {
+			/* Hide lines */
+			display: none;
 		}
 	}
 


### PR DESCRIPTION
For now, in Firefox (which doesn’t support container style queries), charts look as if the `--color-scale-type: discrete` custom property is specified.

<img width="988" height="572" alt="image" src="https://github.com/user-attachments/assets/a3f0c813-7114-4e1e-a0d6-fcbf1e446078" />
