### PR TITLE
fix: logo.svg crops left side of graphic #164

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -10,10 +10,10 @@ text {
 	stroke: hsl(220, 10%, 94%);
 	stroke-width: .1em;
 	stroke-linejoin: round;
-	font: 800 333px/1 system-ui, sans-serif;
+	font: 800 320px/1 system-ui, sans-serif;
 	text-anchor: middle;
 	dominant-baseline: middle;
-	letter-spacing: -.06em;
+	letter-spacing: -.065em;
 	paint-order: stroke fill;
 }
 
@@ -126,7 +126,7 @@ text {
   L 623.393  -506.491
   Z"/>
 
-<text x="44%" y="-55%">
+<text x="48.5%" y="-55%">
 	<tspan class="lt">&lt;</tspan>
 	<tspan class="slash">/</tspan>
 	<tspan class="gt">&gt;</tspan>


### PR DESCRIPTION
**This pull request makes the following changes:**

*Fixes issue #164

Initially, I tried increasing the viewBox width to prevent the clipping of the </> characters. However, I noticed that this change altered the overall dimensions of the SVG, which caused the navigation menu to shift its position.

To maintain the original layout and navigation alignment, I decided to keep the original viewBox and instead fine-tuned the internal elements. I adjusted the font-size to 320px, set the letter-spacing to -0.065em, and slightly repositioned the text to x="48.5%". This ensures that the logo is fully visible and fits perfectly within the existing boundaries without affecting the rest of the UI.