### PR TITLE
Add `gamut` support to `<color-slider>` and `<channel-slider>`

### DIFF
--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -55,6 +55,18 @@ If you don’t want to show the whole range you can also specify `min` and `max`
 <channel-slider space="oklch" channel="l" color="red" min=".3" max=".95"></channel-slider>
 ```
 
+Set a `gamut` to mark the values whose color the gamut can’t reproduce — here, the high-chroma end of an oklch chroma slider isn’t reachable in sRGB, so it’s overlaid with gray (customize the color via `--oog-color`):
+
+```html
+<channel-slider space="oklch" channel="c" color="oklch(70% 0.2 30)" gamut="srgb"></channel-slider>
+```
+
+This can be more than one region — on a hue slider at a fixed lightness and chroma, only some hues are reachable in sRGB:
+
+```html
+<channel-slider space="oklch" channel="h" color="oklch(70% 0.2 30)" gamut="srgb"></channel-slider>
+```
+
 ### Dynamic
 
 You can listen to the `colorchange` event and grab the `color` property to get the current color value.
@@ -127,6 +139,7 @@ All attributes are reactive:
 | Attribute | Property | Property type | Default value | Description |
 |-----------|----------|---------------|---------------|-------------|
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`), forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 | `channel` | `channel` | `string` | `h` | The component to use for the gradient. |
 | `min` | `min` | `number` | `this.refRange[0]` | The minimum value for the slider. |
 | `max` | `max` | `number` | `this.refRange[1]` | The maximum value for the slider. |

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -139,7 +139,7 @@ All attributes are reactive:
 | Attribute | Property | Property type | Default value | Description |
 |-----------|----------|---------------|---------------|-------------|
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to use the display's gamut, forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to use the display's gamut, forwarded to the underlying [`<color-slider>`](../color-slider/#attributes-%26-properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 | `channel` | `channel` | `string` | `h` | The component to use for the gradient. |
 | `min` | `min` | `number` | `this.refRange[0]` | The minimum value for the slider. |
 | `max` | `max` | `number` | `this.refRange[1]` | The maximum value for the slider. |

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -139,7 +139,7 @@ All attributes are reactive:
 | Attribute | Property | Property type | Default value | Description |
 |-----------|----------|---------------|---------------|-------------|
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to follow the display's gamut, forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to use the display's gamut, forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 | `channel` | `channel` | `string` | `h` | The component to use for the gradient. |
 | `min` | `min` | `number` | `this.refRange[0]` | The minimum value for the slider. |
 | `max` | `max` | `number` | `this.refRange[1]` | The maximum value for the slider. |

--- a/src/channel-slider/README.md
+++ b/src/channel-slider/README.md
@@ -139,7 +139,7 @@ All attributes are reactive:
 | Attribute | Property | Property type | Default value | Description |
 |-----------|----------|---------------|---------------|-------------|
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`), forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to follow the display's gamut, forwarded to the underlying [`<color-slider>`](../color-slider/#attributes--properties): the out-of-gamut parts of the band are overlaid with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 | `channel` | `channel` | `string` | `h` | The component to use for the gradient. |
 | `min` | `min` | `number` | `this.refRange[0]` | The minimum value for the slider. |
 | `max` | `max` | `number` | `this.refRange[1]` | The maximum value for the slider. |

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -110,6 +110,10 @@ const Self = class ChannelSlider extends ColorElement {
 			}
 		}
 
+		if (changed.has("gamut")) {
+			this._el.slider.gamut = this.gamut;
+		}
+
 		if (
 			changed.has("defaultColor") ||
 			changed.has("space") ||
@@ -149,6 +153,10 @@ const Self = class ChannelSlider extends ColorElement {
 			stringify (value) {
 				return value?.id;
 			},
+		},
+		gamut: {
+			type: String,
+			default: "",
 		},
 		channel: {
 			type: String,

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -110,10 +110,6 @@ const Self = class ChannelSlider extends ColorElement {
 			}
 		}
 
-		if (changed.has("gamut")) {
-			this._el.slider.gamut = this.gamut;
-		}
-
 		if (
 			changed.has("defaultColor") ||
 			changed.has("space") ||
@@ -157,6 +153,9 @@ const Self = class ChannelSlider extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
+			changed () {
+				this._el.slider.gamut = this.gamut;
+			},
 		},
 		channel: {
 			type: String,

--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -153,6 +153,12 @@ const Self = class ChannelSlider extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
+			convert (value) {
+				if (value && value !== "auto" && value !== "none" && !(value in Self.Color.spaces)) {
+					return this.gamut;
+				}
+				return value;
+			},
 			changed () {
 				this._el.slider.gamut = this.gamut;
 			},

--- a/src/color-picker/README.md
+++ b/src/color-picker/README.md
@@ -128,7 +128,7 @@ All attributes are reactive:
 | – | `space` | `ColorSpace` | `OKLCh` | Color space object corresponding to the `space` attribute. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
 | `alpha` | `alpha` | `boolean` &#124; `undefined` | `undefined` | Whether to show the alpha channel slider or not. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`), or `auto` to follow the display. Forwarded to every channel slider, marking the out-of-gamut parts of each band with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`), or `auto` to use the display's gamut. Forwarded to every channel slider, marking the out-of-gamut parts of each band with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 
 ### Events
 

--- a/src/color-picker/README.md
+++ b/src/color-picker/README.md
@@ -128,6 +128,7 @@ All attributes are reactive:
 | – | `space` | `ColorSpace` | `OKLCh` | Color space object corresponding to the `space` attribute. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
 | `alpha` | `alpha` | `boolean` &#124; `undefined` | `undefined` | Whether to show the alpha channel slider or not. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`), or `auto` to follow the display. Forwarded to every channel slider, marking the out-of-gamut parts of each band with [`--oog-color`](../color-slider/#css-variables). Empty or `none` disables it. |
 
 ### Events
 

--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -239,6 +239,12 @@ const Self = class ColorPicker extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
+			convert (value) {
+				if (value && value !== "auto" && value !== "none" && !(value in Self.Color.spaces)) {
+					return this.gamut;
+				}
+				return value;
+			},
 			changed () {
 				for (let slider of this._el.sliders.children) {
 					slider.gamut = this.gamut;

--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -110,6 +110,7 @@ const Self = class ColorPicker extends ColorElement {
 
 			for (let slider of this._el.sliders.children) {
 				slider.color = this.color;
+				slider.gamut = this.gamut;
 			}
 		}
 
@@ -232,6 +233,16 @@ const Self = class ColorPicker extends ColorElement {
 			},
 			reflect: {
 				from: true,
+			},
+		},
+
+		gamut: {
+			type: String,
+			default: "",
+			changed () {
+				for (let slider of this._el.sliders.children) {
+					slider.gamut = this.gamut;
+				}
 			},
 		},
 	};

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -88,6 +88,25 @@ If you want to show the progress instead, you can specify `"progress"` as the at
 <color-inline></color-inline>
 ```
 
+Set a `gamut` to mark the colors the gamut can't reproduce: out-of-gamut portions of the band are overlaid with gray. This is handy for showing which colors of a wide-gamut space are actually reachable in, say, sRGB:
+
+```html
+<color-slider space="oklch"
+              stops="oklch(65% 0.2 0), oklch(65% 0.2 120), oklch(65% 0.2 240), oklch(65% 0.2 360)"
+              gamut="srgb"
+              oncolorchange="this.nextElementSibling.textContent = this.color"></color-slider>
+<color-inline></color-inline>
+```
+
+The overlay color is customizable via `--oog-color` — use a translucent color to dim rather than hide the out-of-gamut colors:
+
+```html
+<color-slider space="oklch"
+              stops="oklch(65% 0.2 0), oklch(65% 0.2 120), oklch(65% 0.2 240), oklch(65% 0.2 360)"
+              gamut="srgb"
+              style="--oog-color: oklch(50% 0 0 / 0.6)"></color-slider>
+```
+
 All properties are reactive and can be set programmatically:
 
 ```html
@@ -170,6 +189,7 @@ Then use a `color-slider` class on your slider element, and use [CSS variables](
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
 | `stops` | `stops` | `String` &#124; `Array<Color>` | - | Comma-separated list of color stops. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`). When set, the portions of the band whose color falls outside this gamut are overlaid with [`--oog-color`](#css-variables), with a hard edge at each gamut boundary. Empty or `none` disables it. |
 | `min` | `min` | `number` | 0 | The minimum value for the slider. |
 | `max` | `max` | `number` | 1 | The maximum value for the slider. |
 | `step` | `step` | `number` | Computed automatically based on `this.min` and `this.max`. | The granularity that the slider's current value must adhere to. |
@@ -199,6 +219,7 @@ If you’re only using the CSS file, you should set these yourself.
 | `--slider-thumb-border` | `<line-width>` &#124;&#124; `<line-style>` &#124;&#124; `<color>` | Border of the slider thumb. |
 | `--slider-thumb-border-active` | `<line-width>` &#124;&#124; `<line-style>` &#124;&#124; `<color>` | Border of the slider thumb in active state. |
 | `--slider-thumb-scale-active` | `<number>` | Scale transform applied to the slider thumb in active state. |
+| `--oog-color` | `<color>` | Color overlaid on the out-of-[`gamut`](#attributes--properties) parts of the band. Defaults to a light/dark-adaptive neutral gray. |
 | `--tooltip-background` | `<color>` | Background color of the tooltip. |
 | `--tooltip-border-radius` | `<length>` | Border radius of the tooltip. |
 | `--tooltip-pointer-height` | `<length>` | Height of the tooltip pointer triangle. |
@@ -211,6 +232,7 @@ These properties are read-only.
 | Property | Type | Description |
 |----------|------|-------------|
 | `progress` | `number` | The slider value converted to a 0-1 number with `0` corresponding to the min of the range and `1` to the max. |
+| `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes--properties). Always `true` when no gamut is set. |
 
 
 ### Events
@@ -221,6 +243,15 @@ These properties are read-only.
 | `change` | Fired when the color changes due to user action. |
 | `valuechange` | Fired when the value changes for any reason, and once during initialization. |
 | `colorchange` | Fired when the color changes for any reason, and once during initialization. |
+| `ingamutchange` | Fired when the current color's in/out-of-gamut status changes, and once during initialization. |
+
+### States
+
+These [custom states](https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet) can be targeted via the `:state()` pseudo-class.
+
+| Name | Description |
+|------|-------------|
+| `in-gamut` | Present while the currently selected `color` is inside the target [`gamut`](#attributes--properties) (and when no gamut is set). |
 
 ### Parts
 

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -219,7 +219,7 @@ If you’re only using the CSS file, you should set these yourself.
 | `--slider-thumb-border` | `<line-width>` &#124;&#124; `<line-style>` &#124;&#124; `<color>` | Border of the slider thumb. |
 | `--slider-thumb-border-active` | `<line-width>` &#124;&#124; `<line-style>` &#124;&#124; `<color>` | Border of the slider thumb in active state. |
 | `--slider-thumb-scale-active` | `<number>` | Scale transform applied to the slider thumb in active state. |
-| `--oog-color` | `<color>` | Color overlaid on the out-of-[`gamut`](#attributes--properties) parts of the band. Defaults to a light/dark-adaptive neutral gray. |
+| `--oog-color` | `<color>` | Color overlaid on the out-of-[`gamut`](#attributes-%26-properties) parts of the band. Defaults to a light/dark-adaptive neutral gray. |
 | `--tooltip-background` | `<color>` | Background color of the tooltip. |
 | `--tooltip-border-radius` | `<length>` | Border radius of the tooltip. |
 | `--tooltip-pointer-height` | `<length>` | Height of the tooltip pointer triangle. |
@@ -232,8 +232,8 @@ These properties are read-only.
 | Property | Type | Description |
 |----------|------|-------------|
 | `progress` | `number` | The slider value converted to a 0-1 number with `0` corresponding to the min of the range and `1` to the max. |
-| `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes--properties). Always `true` when no gamut is set. |
-| `oogRanges` | `Array<[number, number]>` | The out-of-[`gamut`](#attributes--properties) ranges of the whole band, as `[start, end]` pairs in 0–1 progress (sorted, merged). Empty when no gamut is set or the band is entirely in gamut. |
+| `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes-%26-properties). Always `true` when no gamut is set. |
+| `oogRanges` | `Array<[number, number]>` | The out-of-[`gamut`](#attributes-%26-properties) ranges of the whole band, as `[start, end]` pairs in 0–1 progress (sorted, merged). Empty when no gamut is set or the band is entirely in gamut. |
 
 
 ### Events

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -252,7 +252,7 @@ These [custom states](https://developer.mozilla.org/en-US/docs/Web/API/CustomSta
 
 | Name | Description |
 |------|-------------|
-| `in-gamut` | Present while the currently selected `color` is inside the target [`gamut`](#attributes--properties) (and when no gamut is set). |
+| `in-gamut` | Present while the currently selected `color` is inside the target [`gamut`](#attributes-%26-properties) (and when no gamut is set). |
 
 ### Parts
 

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -189,7 +189,7 @@ Then use a `color-slider` class on your slider element, and use [CSS variables](
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
 | `stops` | `stops` | `String` &#124; `Array<Color>` | - | Comma-separated list of color stops. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to follow the display's gamut (detected via the `color-gamut` media query, and updated if the display changes). When set, the portions of the band whose color falls outside this gamut are overlaid with [`--oog-color`](#css-variables), with a hard edge at each gamut boundary. Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to use the display's gamut (detected once via the `color-gamut` media query). When set, the portions of the band whose color falls outside this gamut are overlaid with [`--oog-color`](#css-variables), with a hard edge at each gamut boundary. Empty or `none` disables it. |
 | `min` | `min` | `number` | 0 | The minimum value for the slider. |
 | `max` | `max` | `number` | 1 | The maximum value for the slider. |
 | `step` | `step` | `number` | Computed automatically based on `this.min` and `this.max`. | The granularity that the slider's current value must adhere to. |
@@ -234,7 +234,6 @@ These properties are read-only.
 | `progress` | `number` | The slider value converted to a 0-1 number with `0` corresponding to the min of the range and `1` to the max. |
 | `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes--properties). Always `true` when no gamut is set. |
 | `oogRanges` | `Array<[number, number]>` | The out-of-[`gamut`](#attributes--properties) ranges of the whole band, as `[start, end]` pairs in 0–1 progress (sorted, merged). Empty when no gamut is set or the band is entirely in gamut. |
-| `displayGamut` | `string` | The display's gamut (`srgb`, `p3`, or `rec2020`), detected via the `color-gamut` media query and kept up to date. This is what `gamut="auto"` resolves to. |
 
 
 ### Events

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -233,6 +233,7 @@ These properties are read-only.
 |----------|------|-------------|
 | `progress` | `number` | The slider value converted to a 0-1 number with `0` corresponding to the min of the range and `1` to the max. |
 | `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes--properties). Always `true` when no gamut is set. |
+| `oogRanges` | `Array<[number, number]>` | The out-of-[`gamut`](#attributes--properties) ranges of the whole band, as `[start, end]` pairs in 0–1 progress (sorted, merged). Empty when no gamut is set or the band is entirely in gamut. |
 
 
 ### Events

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -189,7 +189,7 @@ Then use a `color-slider` class on your slider element, and use [CSS variables](
 | `space` | `space` | `ColorSpace` &#124; `string` | `oklch` | The color space to use for interpolation. |
 | `color` | `color` | `Color` &#124; `string` | `oklch(50% 50% 180)` | The current color value. |
 | `stops` | `stops` | `String` &#124; `Array<Color>` | - | Comma-separated list of color stops. |
-| `gamut` | `gamut` | `string` | `""` | A color gamut id (e.g. `srgb`, `p3`, `rec2020`). When set, the portions of the band whose color falls outside this gamut are overlaid with [`--oog-color`](#css-variables), with a hard edge at each gamut boundary. Empty or `none` disables it. |
+| `gamut` | `gamut` | `string` | `""` | A color gamut id (`srgb`, `p3`, `rec2020`), or `auto` to follow the display's gamut (detected via the `color-gamut` media query, and updated if the display changes). When set, the portions of the band whose color falls outside this gamut are overlaid with [`--oog-color`](#css-variables), with a hard edge at each gamut boundary. Empty or `none` disables it. |
 | `min` | `min` | `number` | 0 | The minimum value for the slider. |
 | `max` | `max` | `number` | 1 | The maximum value for the slider. |
 | `step` | `step` | `number` | Computed automatically based on `this.min` and `this.max`. | The granularity that the slider's current value must adhere to. |
@@ -234,6 +234,7 @@ These properties are read-only.
 | `progress` | `number` | The slider value converted to a 0-1 number with `0` corresponding to the min of the range and `1` to the max. |
 | `inGamut` | `boolean` | Whether the currently selected `color` is inside the target [`gamut`](#attributes--properties). Always `true` when no gamut is set. |
 | `oogRanges` | `Array<[number, number]>` | The out-of-[`gamut`](#attributes--properties) ranges of the whole band, as `[start, end]` pairs in 0–1 progress (sorted, merged). Empty when no gamut is set or the band is entirely in gamut. |
+| `displayGamut` | `string` | The display's gamut (`srgb`, `p3`, or `rec2020`), detected via the `color-gamut` media query and kept up to date. This is what `gamut="auto"` resolves to. |
 
 
 ### Events

--- a/src/color-slider/color-slider.css
+++ b/src/color-slider/color-slider.css
@@ -1,6 +1,11 @@
 :host {
 	display: flex;
 	position: relative;
+
+	/* Color painted over the out-of-gamut parts of the band and over the thumb when the current
+	   color is out of gamut. Defined here (not on .color-slider) so it resolves both on the host
+	   — where the thumb overlay is set — and on the slider, where the band overlay is set. */
+	--_oog-color: var(--oog-color, light-dark(oklch(80% 0.01 220), oklch(30% 0.01 220)));
 }
 
 .color-slider,
@@ -25,6 +30,9 @@
 		linear-gradient(to right var(--in-space,), var(--_slider-color-stops))
 	);
 	--_slider-height: var(--slider-height, 2.2em);
+
+	/* Overlay stops, set by the component when a gamut is in effect; transparent when none. */
+	--_gamut-overlay: var(--slider-gamut-overlay, transparent 0% 100%);
 
 	--_slider-thumb-width: var(--slider-thumb-width, 1em);
 	--_slider-thumb-height-offset: var(--slider-thumb-height-offset, 2px);
@@ -54,7 +62,9 @@
 	width: 100%;
 	-moz-appearance: none;
 	-webkit-appearance: none;
-	background: var(--_slider-gradient), var(--_transparency-grid);
+	background:
+		linear-gradient(to right, var(--_gamut-overlay)), var(--_slider-gradient),
+		var(--_transparency-grid);
 	background-origin: border-box;
 	background-clip: border-box;
 	height: var(--_slider-height);

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -7,6 +7,22 @@ let supports = {
 	fieldSizing: CSS?.supports("field-sizing", "content"),
 };
 
+// Detect the display's color gamut via the color-gamut media query. The values are cumulative
+// (a wider display also matches narrower queries), so the widest match wins.
+function getDisplayGamut () {
+	let mm = globalThis.matchMedia;
+
+	if (mm?.("(color-gamut: rec2020)")?.matches) {
+		return "rec2020";
+	}
+
+	if (mm?.("(color-gamut: p3)")?.matches) {
+		return "p3";
+	}
+
+	return "srgb";
+}
+
 const Self = class ColorSlider extends ColorElement {
 	static tagName = "color-slider";
 	static url = import.meta.url;
@@ -19,6 +35,12 @@ const Self = class ColorSlider extends ColorElement {
 				<input type="number" part="spinner" min="0" max="1" step="0.01" />
 			</slot>
 		<slot></slot>`;
+
+	// MediaQueryLists used to follow the display gamut while gamut="auto".
+	#gamutMedia;
+	#updateDisplayGamut = () => {
+		this.displayGamut = getDisplayGamut();
+	};
 
 	constructor () {
 		super();
@@ -34,11 +56,28 @@ const Self = class ColorSlider extends ColorElement {
 
 		this._el.slider.addEventListener("input", this);
 		this._el.spinner.addEventListener("input", this);
+
+		// Follow the display gamut so gamut="auto" updates if the display changes (e.g. the window
+		// moves to another monitor). The queries are cumulative, so the two widest cover all changes.
+		this.#gamutMedia = [
+			globalThis.matchMedia?.("(color-gamut: rec2020)"),
+			globalThis.matchMedia?.("(color-gamut: p3)"),
+		];
+
+		for (let mq of this.#gamutMedia) {
+			mq?.addEventListener("change", this.#updateDisplayGamut);
+		}
+
+		this.#updateDisplayGamut();
 	}
 
 	disconnectedCallback () {
 		this._el.slider.removeEventListener("input", this);
 		this._el.spinner.removeEventListener("input", this);
+
+		for (let mq of this.#gamutMedia ?? []) {
+			mq?.removeEventListener("change", this.#updateDisplayGamut);
+		}
 	}
 
 	handleEvent (event) {
@@ -115,7 +154,12 @@ const Self = class ColorSlider extends ColorElement {
 		// The color band itself is left untouched; this just layers the out-of-gamut color on top.
 		// Set on the slider (not the host) so the nested var(--_oog-color) in the overlay
 		// resolves where it's defined.
-		if (changed.has("stops") || changed.has("space") || changed.has("gamut")) {
+		if (
+			changed.has("stops") ||
+			changed.has("space") ||
+			changed.has("gamut") ||
+			changed.has("displayGamut")
+		) {
 			let overlay = this.#buildGamutOverlay();
 
 			if (overlay) {
@@ -197,6 +241,11 @@ const Self = class ColorSlider extends ColorElement {
 		}
 
 		return tessellated;
+	}
+
+	// The gamut to actually test against, resolving "auto" to the display's gamut.
+	#effectiveGamut () {
+		return this.gamut === "auto" ? this.displayGamut : this.gamut;
 	}
 
 	/**
@@ -336,6 +385,13 @@ const Self = class ColorSlider extends ColorElement {
 			type: String,
 			default: "",
 		},
+		displayGamut: {
+			type: String,
+			default () {
+				return getDisplayGamut();
+			},
+			reflect: false,
+		},
 
 		color: {
 			get type () {
@@ -348,19 +404,21 @@ const Self = class ColorSlider extends ColorElement {
 		},
 		inGamut: {
 			get () {
-				if (!this.gamut || this.gamut === "none" || !this.color) {
+				let gamut = this.#effectiveGamut();
+
+				if (!gamut || gamut === "none" || !this.color) {
 					return true;
 				}
 
 				try {
-					return this.color.inGamut(this.gamut);
+					return this.color.inGamut(gamut);
 				}
 				catch (error) {
 					// NOTE: invalid gamut id; treat the color as in-gamut.
 					return true;
 				}
 			},
-			dependencies: ["color", "gamut"],
+			dependencies: ["color", "gamut", "displayGamut"],
 		},
 		scales: {
 			get () {
@@ -382,8 +440,9 @@ const Self = class ColorSlider extends ColorElement {
 			get () {
 				let scales = this.scales;
 				let bands = scales.length;
+				let gamut = this.#effectiveGamut();
 
-				if (bands === 0 || !this.gamut) {
+				if (bands === 0 || !gamut) {
 					return [];
 				}
 
@@ -395,7 +454,7 @@ const Self = class ColorSlider extends ColorElement {
 				let ranges = [];
 
 				for (let i = 0; i < bands; i++) {
-					let bandRanges = getGamutBoundaries(this.gamut, scales[i], { samples });
+					let bandRanges = getGamutBoundaries(gamut, scales[i], { samples });
 
 					if (!bandRanges) {
 						// gamut is "none" or an unknown id: nothing out of gamut.
@@ -420,7 +479,7 @@ const Self = class ColorSlider extends ColorElement {
 
 				return ranges;
 			},
-			dependencies: ["scales", "gamut"],
+			dependencies: ["scales", "gamut", "displayGamut"],
 		},
 
 		tooltip: {

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -7,22 +7,6 @@ let supports = {
 	fieldSizing: CSS?.supports("field-sizing", "content"),
 };
 
-// Detect the display's color gamut via the color-gamut media query. The values are cumulative
-// (a wider display also matches narrower queries), so the widest match wins.
-function getDisplayGamut () {
-	let mm = globalThis.matchMedia;
-
-	if (mm?.("(color-gamut: rec2020)")?.matches) {
-		return "rec2020";
-	}
-
-	if (mm?.("(color-gamut: p3)")?.matches) {
-		return "p3";
-	}
-
-	return "srgb";
-}
-
 const Self = class ColorSlider extends ColorElement {
 	static tagName = "color-slider";
 	static url = import.meta.url;
@@ -353,7 +337,24 @@ const Self = class ColorSlider extends ColorElement {
 			default: "",
 			// Resolve "auto" to the display's gamut, once, when the value is set.
 			convert (value) {
-				return value === "auto" ? getDisplayGamut() : value;
+				if (value !== "auto") {
+					return value;
+				}
+
+				if (!globalThis.matchMedia) {
+					return "srgb";
+				}
+
+				// TODO listen to updates (can happen if window is moved to another screen)
+				if (matchMedia("(color-gamut: rec2020)").matches) {
+					return "rec2020";
+				}
+
+				if (matchMedia("(color-gamut: p3)").matches) {
+					return "p3";
+				}
+
+				return "srgb";
 			},
 		},
 

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -200,53 +200,16 @@ const Self = class ColorSlider extends ColorElement {
 	}
 
 	/**
-	 * Build the value of the `--slider-gamut-overlay` custom property: gradient color stops that paint
-	 * `--_oog-color` over each out-of-gamut range of the band (from {@link getGamutBoundaries}) and are
-	 * transparent in between, with a hard edge at each gamut boundary.
+	 * Build the value of the `--slider-gamut-overlay` custom property from {@link ColorSlider#oogRanges}:
+	 * `--_oog-color` over each out-of-gamut range, transparent in between, with a hard edge at each
+	 * gamut boundary.
 	 *
 	 * @returns {string | null} Comma-separated overlay color stops, or null when nothing is out of gamut.
 	 */
 	#buildGamutOverlay () {
-		let scales = this.scales;
-		let bands = scales.length;
+		let oogRanges = this.oogRanges;
 
-		// Need at least one band (≥ 2 stops) to interpolate along.
-		if (bands === 0 || !this.gamut) {
-			return null;
-		}
-
-		// Scan each band (a single interpolation between two stops) independently. A non-polar one is
-		// ~monotone, so its endpoints + midpoint (samples = 2) suffice; a polar one can weave in and out
-		// of gamut, so it needs dense sampling.
-		// NOTE: an out-of-gamut → in → out island that misses the midpoint is still under-sampled.
-		let samples = this.space.isPolar ? 100 : 2;
-		let oogRanges = [];
-
-		for (let i = 0; i < bands; i++) {
-			let ranges = getGamutBoundaries(this.gamut, scales[i], { samples });
-
-			// No gamut at all: nothing to paint.
-			if (!ranges) {
-				return null;
-			}
-
-			// Place each band-local [0, 1] range into its slot in the whole track, merging with the
-			// previous range when they touch across a band boundary (both bands out of gamut there).
-			for (let [start, end] of ranges) {
-				let from = (i + start) / bands;
-				let to = (i + end) / bands;
-				let last = oogRanges.at(-1);
-
-				if (last && last[1] === from) {
-					last[1] = to;
-				}
-				else {
-					oogRanges.push([from, to]);
-				}
-			}
-		}
-
-		// The whole band is in gamut: nothing to paint.
+		// The whole band is in gamut (or no gamut set): nothing to paint.
 		if (oogRanges.length === 0) {
 			return null;
 		}
@@ -414,6 +377,50 @@ const Self = class ColorSlider extends ColorElement {
 				return scales;
 			},
 			dependencies: ["stops", "space"],
+		},
+		oogRanges: {
+			get () {
+				let scales = this.scales;
+				let bands = scales.length;
+
+				if (bands === 0 || !this.gamut) {
+					return [];
+				}
+
+				// Scan each band (one interpolation between two stops) independently. A non-polar one is
+				// ~monotone, so its endpoints + midpoint (samples = 2) suffice; a polar one can weave in
+				// and out of gamut, so it needs dense sampling.
+				// NOTE: an out-of-gamut → in → out island that misses the midpoint is still under-sampled.
+				let samples = this.space.isPolar ? 100 : 2;
+				let ranges = [];
+
+				for (let i = 0; i < bands; i++) {
+					let bandRanges = getGamutBoundaries(this.gamut, scales[i], { samples });
+
+					if (!bandRanges) {
+						// gamut is "none" or an unknown id: nothing out of gamut.
+						return [];
+					}
+
+					// Place each band-local [0, 1] range into its slot in the whole track, merging with
+					// the previous range when they touch across a band boundary (both out of gamut there).
+					for (let [start, end] of bandRanges) {
+						let from = (i + start) / bands;
+						let to = (i + end) / bands;
+						let last = ranges.at(-1);
+
+						if (last && last[1] === from) {
+							last[1] = to;
+						}
+						else {
+							ranges.push([from, to]);
+						}
+					}
+				}
+
+				return ranges;
+			},
+			dependencies: ["scales", "gamut"],
 		},
 
 		tooltip: {

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -1,5 +1,6 @@
 import ColorElement from "../common/color-element.js";
 import { getStep } from "../common/util.js";
+import { getGamutBoundaries } from "./gamut-boundaries.js";
 
 let supports = {
 	inSpace: CSS?.supports("background", "linear-gradient(in oklab, red, tan)"),
@@ -110,6 +111,27 @@ const Self = class ColorSlider extends ColorElement {
 			this.style.setProperty("--slider-color-stops", stops);
 		}
 
+		// Paint a separate overlay over the parts of the band that fall outside the target gamut.
+		// The color band itself is left untouched; this just layers the out-of-gamut color on top.
+		// Set on the slider (not the host) so the nested var(--_oog-color) in the overlay
+		// resolves where it's defined.
+		if (changed.has("stops") || changed.has("space") || changed.has("gamut")) {
+			let overlay = this.#buildGamutOverlay();
+
+			if (overlay) {
+				this._el.slider.style.setProperty("--slider-gamut-overlay", overlay);
+			}
+			else {
+				this._el.slider.style.removeProperty("--slider-gamut-overlay");
+			}
+		}
+
+		// Reflect whether the currently selected color is within the target gamut,
+		// so it can be styled via :state(in-gamut).
+		if (changed.has("inGamut")) {
+			this.toggleState("in-gamut", this.inGamut);
+		}
+
 		if (changed.has("space") && supports.inSpace) {
 			let space = this.space;
 			let spaceId = space.id;
@@ -175,6 +197,79 @@ const Self = class ColorSlider extends ColorElement {
 		}
 
 		return tessellated;
+	}
+
+	/**
+	 * Build the value of the `--slider-gamut-overlay` custom property: gradient color stops that paint
+	 * `--_oog-color` over each out-of-gamut range of the band (from {@link getGamutBoundaries}) and are
+	 * transparent in between, with a hard edge at each gamut boundary.
+	 *
+	 * @returns {string | null} Comma-separated overlay color stops, or null when nothing is out of gamut.
+	 */
+	#buildGamutOverlay () {
+		let scales = this.scales;
+		let bands = scales.length;
+
+		// Need at least one band (≥ 2 stops) to interpolate along.
+		if (bands === 0 || !this.gamut) {
+			return null;
+		}
+
+		// Scan each band (a single interpolation between two stops) independently. A non-polar one is
+		// ~monotone, so its endpoints + midpoint (samples = 2) suffice; a polar one can weave in and out
+		// of gamut, so it needs dense sampling.
+		// NOTE: an out-of-gamut → in → out island that misses the midpoint is still under-sampled.
+		let samples = this.space.isPolar ? 100 : 2;
+		let oogRanges = [];
+
+		for (let i = 0; i < bands; i++) {
+			let ranges = getGamutBoundaries(this.gamut, scales[i], { samples });
+
+			// No gamut at all: nothing to paint.
+			if (!ranges) {
+				return null;
+			}
+
+			// Place each band-local [0, 1] range into its slot in the whole track, merging with the
+			// previous range when they touch across a band boundary (both bands out of gamut there).
+			for (let [start, end] of ranges) {
+				let from = (i + start) / bands;
+				let to = (i + end) / bands;
+				let last = oogRanges.at(-1);
+
+				if (last && last[1] === from) {
+					last[1] = to;
+				}
+				else {
+					oogRanges.push([from, to]);
+				}
+			}
+		}
+
+		// The whole band is in gamut: nothing to paint.
+		if (oogRanges.length === 0) {
+			return null;
+		}
+
+		// Paint --_oog-color over each out-of-gamut range, transparent in between.
+		// Adjacent stops at the same position produce the hard edge at each boundary.
+		let pos = p => `${+(p * 100).toPrecision(4)}%`;
+		let stops = [];
+		let cursor = 0;
+
+		for (let [start, end] of oogRanges) {
+			if (start > cursor) {
+				stops.push(`transparent ${pos(cursor)} ${pos(start)}`);
+			}
+			stops.push(`var(--_oog-color) ${pos(start)} ${pos(end)}`);
+			cursor = end;
+		}
+
+		if (cursor < 1) {
+			stops.push(`transparent ${pos(cursor)} 100%`);
+		}
+
+		return stops.join(", ");
 	}
 
 	get progress () {
@@ -274,6 +369,11 @@ const Self = class ColorSlider extends ColorElement {
 			},
 		},
 
+		gamut: {
+			type: String,
+			default: "",
+		},
+
 		color: {
 			get type () {
 				return Self.Color;
@@ -282,6 +382,22 @@ const Self = class ColorSlider extends ColorElement {
 				return this.colorAt(this.value);
 			},
 			dependencies: ["scales", "value"],
+		},
+		inGamut: {
+			get () {
+				if (!this.gamut || this.gamut === "none" || !this.color) {
+					return true;
+				}
+
+				try {
+					return this.color.inGamut(this.gamut);
+				}
+				catch (error) {
+					// NOTE: invalid gamut id; treat the color as in-gamut.
+					return true;
+				}
+			},
+			dependencies: ["color", "gamut"],
 		},
 		scales: {
 			get () {
@@ -316,6 +432,9 @@ const Self = class ColorSlider extends ColorElement {
 		},
 		colorchange: {
 			propchange: "color",
+		},
+		ingamutchange: {
+			propchange: "inGamut",
 		},
 	};
 

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -338,6 +338,9 @@ const Self = class ColorSlider extends ColorElement {
 			// Resolve "auto" to the display's gamut, once, when the value is set.
 			convert (value) {
 				if (value !== "auto") {
+					if (value && value !== "none" && !(value in Self.Color.spaces)) {
+						return this.gamut;
+					}
 					return value;
 				}
 

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -36,12 +36,6 @@ const Self = class ColorSlider extends ColorElement {
 			</slot>
 		<slot></slot>`;
 
-	// MediaQueryLists used to follow the display gamut while gamut="auto".
-	#gamutMedia;
-	#updateDisplayGamut = () => {
-		this.displayGamut = getDisplayGamut();
-	};
-
 	constructor () {
 		super();
 
@@ -56,28 +50,11 @@ const Self = class ColorSlider extends ColorElement {
 
 		this._el.slider.addEventListener("input", this);
 		this._el.spinner.addEventListener("input", this);
-
-		// Follow the display gamut so gamut="auto" updates if the display changes (e.g. the window
-		// moves to another monitor). The queries are cumulative, so the two widest cover all changes.
-		this.#gamutMedia = [
-			globalThis.matchMedia?.("(color-gamut: rec2020)"),
-			globalThis.matchMedia?.("(color-gamut: p3)"),
-		];
-
-		for (let mq of this.#gamutMedia) {
-			mq?.addEventListener("change", this.#updateDisplayGamut);
-		}
-
-		this.#updateDisplayGamut();
 	}
 
 	disconnectedCallback () {
 		this._el.slider.removeEventListener("input", this);
 		this._el.spinner.removeEventListener("input", this);
-
-		for (let mq of this.#gamutMedia ?? []) {
-			mq?.removeEventListener("change", this.#updateDisplayGamut);
-		}
 	}
 
 	handleEvent (event) {
@@ -154,12 +131,7 @@ const Self = class ColorSlider extends ColorElement {
 		// The color band itself is left untouched; this just layers the out-of-gamut color on top.
 		// Set on the slider (not the host) so the nested var(--_oog-color) in the overlay
 		// resolves where it's defined.
-		if (
-			changed.has("stops") ||
-			changed.has("space") ||
-			changed.has("gamut") ||
-			changed.has("displayGamut")
-		) {
+		if (changed.has("stops") || changed.has("space") || changed.has("gamut")) {
 			let overlay = this.#buildGamutOverlay();
 
 			if (overlay) {
@@ -241,11 +213,6 @@ const Self = class ColorSlider extends ColorElement {
 		}
 
 		return tessellated;
-	}
-
-	// The gamut to actually test against, resolving "auto" to the display's gamut.
-	#effectiveGamut () {
-		return this.gamut === "auto" ? this.displayGamut : this.gamut;
 	}
 
 	/**
@@ -384,13 +351,10 @@ const Self = class ColorSlider extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
-		},
-		displayGamut: {
-			type: String,
-			default () {
-				return getDisplayGamut();
+			// Resolve "auto" to the display's gamut, once, when the value is set.
+			convert (value) {
+				return value === "auto" ? getDisplayGamut() : value;
 			},
-			reflect: false,
 		},
 
 		color: {
@@ -404,21 +368,19 @@ const Self = class ColorSlider extends ColorElement {
 		},
 		inGamut: {
 			get () {
-				let gamut = this.#effectiveGamut();
-
-				if (!gamut || gamut === "none" || !this.color) {
+				if (!this.gamut || this.gamut === "none" || !this.color) {
 					return true;
 				}
 
 				try {
-					return this.color.inGamut(gamut);
+					return this.color.inGamut(this.gamut);
 				}
 				catch (error) {
 					// NOTE: invalid gamut id; treat the color as in-gamut.
 					return true;
 				}
 			},
-			dependencies: ["color", "gamut", "displayGamut"],
+			dependencies: ["color", "gamut"],
 		},
 		scales: {
 			get () {
@@ -440,7 +402,7 @@ const Self = class ColorSlider extends ColorElement {
 			get () {
 				let scales = this.scales;
 				let bands = scales.length;
-				let gamut = this.#effectiveGamut();
+				let gamut = this.gamut;
 
 				if (bands === 0 || !gamut) {
 					return [];
@@ -479,7 +441,7 @@ const Self = class ColorSlider extends ColorElement {
 
 				return ranges;
 			},
-			dependencies: ["scales", "gamut", "displayGamut"],
+			dependencies: ["scales", "gamut"],
 		},
 
 		tooltip: {

--- a/src/color-slider/gamut-boundaries.js
+++ b/src/color-slider/gamut-boundaries.js
@@ -1,0 +1,69 @@
+/**
+ * Find the ranges of a progress interval where a color is outside a given gamut.
+ *
+ * Gamut membership is a property of the interpolated color, which CSS can't express, so it has to be
+ * evaluated in JS. The color can enter and leave the gamut any number of times (e.g. along a hue
+ * ramp), so we sample uniformly to bracket every transition, then bisect each bracket (where a single
+ * crossing is assumed) to pin the exact boundary.
+ *
+ * @param {string} gamut - A color.js gamut id (e.g. "srgb", "p3", "rec2020").
+ * @param {(progress: number) => import("colorjs.io").default} range - Returns the color at a given
+ *   progress, e.g. an interpolation function.
+ * @param {object} [options]
+ * @param {number} [options.min=0] @param {number} [options.max=1] - The progress interval to scan.
+ * @param {number} [options.samples=100] - Number of uniform samples used to *detect* transitions
+ *   (precision comes from the bisection, not from this). There must be at least one sample inside
+ *   every in/out run; a value of 1 (endpoints only) suffices when membership is monotone over the
+ *   interval.
+ * @returns {number[][] | null} Sorted `[start, end]` out-of-gamut ranges within `[min, max]` (empty
+ *   if entirely in gamut), or null when there is no gamut to apply (unset or "none").
+ */
+export function getGamutBoundaries (gamut, range, { min = 0, max = 1, samples = 100 } = {}) {
+	if (!gamut || gamut === "none") {
+		return null;
+	}
+
+	let inGamut = progress => Boolean(range(progress)?.inGamut(gamut));
+	let at = k => min + (k / samples) * (max - min);
+	let startsInside = inGamut(min);
+
+	// Find every in/out transition, refined to a precise position.
+	let crossings = [];
+	let previous = startsInside;
+
+	for (let k = 1; k <= samples; k++) {
+		let inside = inGamut(at(k));
+		if (inside === previous) {
+			continue;
+		}
+
+		let lo = at(k - 1);
+		let hi = at(k);
+		for (let iteration = 0; iteration < 16; iteration++) {
+			let mid = (lo + hi) / 2;
+			if (inGamut(mid) === previous) {
+				lo = mid;
+			}
+			else {
+				hi = mid;
+			}
+		}
+
+		crossings.push(hi);
+		previous = inside;
+	}
+
+	// Pair up the segments delimited by the crossings, keeping the out-of-gamut ones.
+	let edges = [min, ...crossings, max];
+	let ranges = [];
+	let inside = startsInside;
+
+	for (let i = 0; i < edges.length - 1; i++) {
+		if (!inside) {
+			ranges.push([edges[i], edges[i + 1]]);
+		}
+		inside = !inside;
+	}
+
+	return ranges;
+}

--- a/src/color-slider/gamut-boundaries.js
+++ b/src/color-slider/gamut-boundaries.js
@@ -25,7 +25,13 @@ export function getGamutBoundaries (gamut, range, { min = 0, max = 1, samples = 
 
 	let inGamut = progress => Boolean(range(progress)?.inGamut(gamut));
 	let at = k => min + (k / samples) * (max - min);
-	let startsInside = inGamut(min);
+	let startsInside;
+	try {
+		startsInside = inGamut(min);
+	}
+	catch {
+		return null;
+	}
 
 	// Find every in/out transition, refined to a precise position.
 	let crossings = [];


### PR DESCRIPTION
## Summary

Adds out-of-gamut visualization to `<color-slider>` and `<channel-slider>`. When a `gamut` is set, the parts of the slider's band whose interpolated color falls outside that gamut are overlaid with a customizable gray, so you can see at a glance which values are actually reproducible (e.g. in sRGB).

## `<color-slider>`

- **`gamut`** — a color.js gamut id (`srgb`, `p3`, `rec2020`), or **`auto`** to follow the display's gamut (detected via the `color-gamut` media query, and updated live if the display changes, e.g. the window moves to another monitor). `""` or `"none"` disables it.
- Out-of-gamut regions are painted with **`--oog-color`** (default: a light/dark-adaptive neutral), with hard edges at the gamut boundaries. The color band itself is left untouched — the overlay is a separate gradient layer.
- **`inGamut`** getter, **`ingamutchange`** event, and **`:state(in-gamut)`** reflecting whether the current color is in gamut (no built-in visual cue — style it via the state).
- **`oogRanges`** getter — the whole-band out-of-gamut ranges as `[start, end]` pairs in 0–1 progress (sorted, merged).
- **`displayGamut`** — the display's detected gamut, i.e. what `gamut="auto"` resolves to.

## `<channel-slider>`

- **`gamut`** property that forwards to its inner `<color-slider>` (`auto` included). `--oog-color` inherits through the shadow boundary, so it needs no forwarding.

## `<color-picker>`

- **`gamut`** property that forwards to every channel slider, so each channel's band marks its out-of-gamut regions. Same values as `<color-slider>`, including `auto`.

## How it works

Gamut membership is a per-pixel property of the *interpolated* color, which CSS can't express, so it's computed in JS. A new `getGamutBoundaries()` util scans each stop-pair interpolation by sampling + bisection — densely for polar interpolations (which can weave in and out of gamut) and at just the endpoints + midpoint for non-polar ones. The per-band ranges are offset into the whole track, merged, rendered as the overlay gradient, and exposed via `oogRanges`.

`background-blend-mode` can't produce transparency and `mask` clips the thumb, which is why a painted overlay (rather than making the band transparent) is the approach.

## Demos

Live examples added to both component READMEs (chroma + hue gamut demos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
