### PR TITLE
Validate gamut ids

### DIFF
--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -153,6 +153,12 @@ const Self = class ChannelSlider extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
+			convert (value) {
+				if (value && value !== "auto" && value !== "none" && !(value in Self.Color.spaces)) {
+					return this.gamut;
+				}
+				return value;
+			},
 			changed () {
 				this._el.slider.gamut = this.gamut;
 			},

--- a/src/color-picker/color-picker.js
+++ b/src/color-picker/color-picker.js
@@ -239,6 +239,12 @@ const Self = class ColorPicker extends ColorElement {
 		gamut: {
 			type: String,
 			default: "",
+			convert (value) {
+				if (value && value !== "auto" && value !== "none" && !(value in Self.Color.spaces)) {
+					return this.gamut;
+				}
+				return value;
+			},
 			changed () {
 				for (let slider of this._el.sliders.children) {
 					slider.gamut = this.gamut;

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -338,6 +338,9 @@ const Self = class ColorSlider extends ColorElement {
 			// Resolve "auto" to the display's gamut, once, when the value is set.
 			convert (value) {
 				if (value !== "auto") {
+					if (value && value !== "none" && !(value in Self.Color.spaces)) {
+						return this.gamut;
+					}
 					return value;
 				}
 

--- a/src/color-slider/gamut-boundaries.js
+++ b/src/color-slider/gamut-boundaries.js
@@ -25,7 +25,13 @@ export function getGamutBoundaries (gamut, range, { min = 0, max = 1, samples = 
 
 	let inGamut = progress => Boolean(range(progress)?.inGamut(gamut));
 	let at = k => min + (k / samples) * (max - min);
-	let startsInside = inGamut(min);
+	let startsInside;
+	try {
+		startsInside = inGamut(min);
+	}
+	catch {
+		return null;
+	}
 
 	// Find every in/out transition, refined to a precise position.
 	let crossings = [];


### PR DESCRIPTION
## Summary
- `getGamutBoundaries()` returns `null` instead of throwing on invalid gamut ids
- `convert()` rejects invalid gamut ids and falls back to the previous value in `color-slider`, `channel-slider`, and `color-picker`

Addresses https://github.com/color-js/elements/pull/231#discussion_r3359282044

## Test plan
- Set `gamut` to an invalid id (e.g. `"bogus"`) → value stays unchanged
- Set `gamut` to valid ids (`"srgb"`, `"p3"`, `"auto"`, `"none"`, `""`) → accepted normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)