### PR TITLE
[color-swatch] Fix popover centering in Firefox (regression)

### DIFF
--- a/src/color-swatch/color-swatch.css
+++ b/src/color-swatch/color-swatch.css
@@ -151,10 +151,11 @@ slot {
 			overflow: visible; /* show the triangle pointer */
 			position: fixed;
 			inset: auto;
+			bottom: anchor(top);
+			left: anchor(center);
+			translate: -50% 0;
 			margin: 0 0 calc(var(--_pointer-height) * 0.8);
-			translate: none;
 			position-anchor: --swatch;
-			position-area: top;
 			position-try-fallbacks: flip-block;
 			/* Query the active fallback so the pointer can flip with it (below). */
 			container-type: anchored;


### PR DESCRIPTION
## Summary
- Use `anchor()` functions (`bottom: anchor(top)`, `left: anchor(center)`) instead of `position-area: top` for popover positioning
- Firefox does not center the popover with `position-area` when the anchor is inside a chart's complex layout context (e.g. `contain: size`, absolute positioning)

**Known issue:** Firefox still clips anchor-positioned top-layer elements by ancestor `overflow: hidden` — a browser bug with no CSS-only workaround. No existing Bugzilla report found; needs to be filed.

## Test plan
- [x] Hover compact swatches — tooltip centered above swatch (Chrome, Firefox, Safari)
- [x] Hover chart swatches — tooltip centered (Chrome ✓, Firefox: centered but clipped by chart overflow)
- [x] `flip-block` still works when swatch is near viewport top edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)