### PR TITLE
Fix hue-wheel extra points: oversized and not rounded

### DIFF
--- a/src/hue-wheel/hue-wheel-global.css
+++ b/src/hue-wheel/hue-wheel-global.css
@@ -15,6 +15,15 @@ hue-wheel color-scale::part(color-swatch) {
 	top: 50%;
 	left: 50%;
 	margin: 0;
+
+	/* <color-scale> sets size="large" on its swatches and uses subgrid +
+	   containment for even heights. Undo both so the dot shrinks to fit. */
+	display: inline-flex;
+	inline-size: fit-content;
+	min-block-size: 0;
+	contain: none;
+	container-type: normal;
+
 	transition: 150ms scale;
 
 	--_frac: clamp(
@@ -29,6 +38,13 @@ hue-wheel color-scale::part(color-swatch) {
 /* No channel → every point rides the middle of the ring. */
 hue-wheel[ring] color-scale::part(color-swatch) {
 	--_r: calc((1 - var(--ring-thickness, 0.35) / 2) * 50cqi);
+}
+
+/* Strip padding and min-height so the dot sizes to --point-size + border. */
+hue-wheel > color-swatch::part(swatch),
+hue-wheel color-scale::part(swatch) {
+	padding: 0;
+	min-block-size: 0;
 }
 
 /* Grow a point on hover so a cluster stays explorable; its details are in the


### PR DESCRIPTION
## Summary

- Override `size="large"` and subgrid styles on `<color-scale>`'s swatches via `::part()` so the dots shrink to fit their content
- Strip inner swatch padding and min-height so dots size to `--point-size` + border

Closes #237

## Test plan

- [x] Verify extra points on the hue-wheel page are small, circular dots
- [x] Hover a dot and confirm the tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)