### PR TITLE
Handle "none" channels (e.g. hue of white in OKLCh)

### DIFF
--- a/src/channel-slider/channel-slider.js
+++ b/src/channel-slider/channel-slider.js
@@ -97,9 +97,10 @@ const Self = class ChannelSlider extends ColorElement {
 			this._el.slider[name] = this[name];
 
 			if (name !== "space") {
-				this._el.spinner[name] = this[name];
+				// Empty string is the native input's no-value form for "none" channels.
+				this._el.spinner[name] = this[name] ?? "";
 
-				if (name === "value" && this.value !== undefined) {
+				if (name === "value" && this.value != null) {
 					this._el.spinner.value = Number(this.value.toPrecision(4));
 
 					if (!CSS.supports("field-sizing", "content")) {

--- a/src/color-slider/README.md
+++ b/src/color-slider/README.md
@@ -264,6 +264,7 @@ These [custom states](https://developer.mozilla.org/en-US/docs/Web/API/CustomSta
 | Name       | Description                                                                                                                         |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `in-gamut` | Present while the currently selected `color` is inside the target [`gamut`](#attributes-%26-properties) (and when no gamut is set). |
+| `no-value` | Present when `value` is `null` (e.g. a "none" channel like the hue of white in OKLCh). The slider thumb is hidden; the first interaction seeds a value. |
 
 ### Parts
 

--- a/src/color-slider/color-slider.css
+++ b/src/color-slider/color-slider.css
@@ -124,6 +124,16 @@
 	scale: var(--_slider-thumb-scale-active);
 }
 
+/* Hide the thumb until a value is seeded (the track still accepts clicks).
+   Separate rules: Chrome drops a combined vendor-prefixed pseudo-element selector list. */
+:host(:state(no-value)) .color-slider::-webkit-slider-thumb {
+	opacity: 0;
+}
+
+:host(:state(no-value)) .color-slider::-moz-range-thumb {
+	opacity: 0;
+}
+
 .slider-tooltip {
 	position: absolute;
 	left: clamp(

--- a/src/color-slider/color-slider.js
+++ b/src/color-slider/color-slider.js
@@ -65,6 +65,13 @@ const Self = class ColorSlider extends ColorElement {
 			this._el.slider[name] = this[name];
 
 			let value = this[name];
+			// Empty string is the native input's no-value form; short-circuit so the
+			// tooltip-progress branch below doesn't coerce null into a misleading number.
+			if (value == null) {
+				this._el.spinner[name] = "";
+				continue;
+			}
+
 			if (this.tooltip === "progress") {
 				if (name === "value" || name === "defaultValue") {
 					value = +(this.progress * 100).toPrecision(4);
@@ -77,8 +84,11 @@ const Self = class ColorSlider extends ColorElement {
 			this._el.spinner[name] = +(+value).toPrecision(4);
 		}
 
+		if (changed.has("value")) {
+			this.toggleState("no-value", this.value == null);
+		}
+
 		if (changed.has("stops")) {
-			// FIXME will fail if there are none values
 			let stops = this.stops;
 			let supported = stops.every(color => CSS.supports("color", color));
 
@@ -105,6 +115,14 @@ const Self = class ColorSlider extends ColorElement {
 			if (!supported || farApart) {
 				stops = this.tessellateStops({ steps: 3 });
 			}
+
+			// Replace "none" with 0 so the gradient doesn't render CSS's missing-channel artifacts.
+			// FIXME: out-of-gamut stops gamut-map to misleading colors.
+			stops = stops.map(color => {
+				let fallback = color.clone();
+				fallback.coords = fallback.coords.map(coord => coord ?? 0);
+				return fallback;
+			});
 
 			stops = stops.map(color => color.display()).join(", ");
 
@@ -154,10 +172,11 @@ const Self = class ColorSlider extends ColorElement {
 		}
 
 		if (changed.has("value") || changed.has("min") || changed.has("max")) {
-			this.style.setProperty("--progress", this.progress);
+			// `progressAt(null)` would coerce to a misleading number; drop the property instead.
+			this.style.setProperty("--progress", this.value == null ? null : this.progress);
 
 			if (changed.has("value") && !supports.fieldSizing) {
-				let valueStr = this.value + "";
+				let valueStr = this._el.spinner.value;
 				this._el.spinner.style.setProperty("--value-length", valueStr.length);
 			}
 		}
@@ -243,6 +262,10 @@ const Self = class ColorSlider extends ColorElement {
 	}
 
 	colorAt (value) {
+		if (value == null) {
+			return null;
+		}
+
 		let progress = this.progressAt(value);
 		return this.colorAtProgress(progress);
 	}

--- a/src/hue-wheel/hue-wheel.js
+++ b/src/hue-wheel/hue-wheel.js
@@ -386,17 +386,16 @@ const Self = class HueWheel extends ColorElement {
 		let marker = this.marker;
 		let color = this.color;
 
-		marker.hidden = !color;
-		if (!color) {
-			return;
-		}
+		marker.hidden = this.hueValue == null;
 
 		marker.style.setProperty("--hue", `${this.hueValue ?? 0}deg`);
-		if (this.channelCoord) {
+		if (this.channelCoord && this.channelValue != null) {
 			marker.style.setProperty("--channel", this.channelValue);
 		}
-		// The marker reflects the current color; a slotted <color-swatch> renders it too.
-		marker.color = color;
+		if (color) {
+			// The marker reflects the current color; a slotted <color-swatch> renders it too.
+			marker.color = color;
+		}
 
 		// Expose the hue as the slider value. The radial axis isn't a second slider
 		// yet (a known a11y gap), so fold its value into aria-valuetext alongside the
@@ -406,9 +405,10 @@ const Self = class HueWheel extends ColorElement {
 		marker.setAttribute("aria-valuemax", hueMax);
 		marker.setAttribute("aria-valuenow", Math.round(this.hueValue ?? 0));
 
-		let valueText = `${this.hueCoord.name} ${Math.round(this.hueValue ?? 0)}`;
+		// Announce "none" so screen readers don't claim a value that isn't there.
+		let valueText = `${this.hueCoord.name} ${this.hueValue == null ? "none" : Math.round(this.hueValue)}`;
 		if (this.channelCoord) {
-			valueText += `, ${this.channelCoord.name} ${+this.channelValue.toPrecision(3)}`;
+			valueText += `, ${this.channelCoord.name} ${this.channelValue == null ? "none" : +this.channelValue.toPrecision(3)}`;
 		}
 		marker.setAttribute("aria-valuetext", valueText);
 


### PR DESCRIPTION
## Summary

- **color-slider**: guard `colorAt` against null values, hide thumb via `:state(no-value)`, replace "none" coords in gradient stops with 0
- **channel-slider**: pass null through to spinner as empty string
- **hue-wheel**: hide marker when `hueValue` is null (covers both missing color and "none" hue), announce "none" in ARIA valuetext

Fixes `<color-picker color="white">` crashing — Color.js returns `null` for "none" channel values (e.g. hue of white in OKLCh), which previously caused `toPrecision` calls on null.

## Test plan

- [x] `<color-picker color="white">` renders without error, hue slider has no thumb
- [x] `<color-picker color="black">` same behavior
- [x] `<color-picker color="oklch(none none none)">` all three sliders have no thumb
- [x] `<hue-wheel color="white">` shows no marker; clicking the wheel seeds one
- [x] Existing demos on color-picker, hue-wheel, channel-slider pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
